### PR TITLE
Refocus health calculators on dedicated HSA and FSA flows

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import NavigationHeader from "@/components/navigation-header";
 import CalculatorHub from "@/pages/calculator-hub";
 import HSACalculator from "@/pages/hsa-calculator";
+import FSACalculator from "@/pages/fsa-calculator";
 import CommuterCalculator from "@/pages/commuter-calculator";
 import LifeInsuranceCalculator from "@/pages/life-insurance-calculator";
 import RetirementCalculator from "@/pages/retirement-calculator";
@@ -17,6 +18,7 @@ function Router() {
     <Switch>
       <Route path="/" component={CalculatorHub} />
       <Route path="/hsa" component={HSACalculator} />
+      <Route path="/fsa" component={FSACalculator} />
       <Route path="/commuter" component={CommuterCalculator} />
       <Route path="/life-insurance" component={LifeInsuranceCalculator} />
       <Route path="/retirement" component={RetirementCalculator} />

--- a/client/src/components/calculators/decision-slider.tsx
+++ b/client/src/components/calculators/decision-slider.tsx
@@ -1,0 +1,66 @@
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+
+interface DecisionSliderProps {
+  id: string;
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (value: number) => void;
+  formatValue?: (value: number) => string;
+  helperText?: string;
+  focusLabel?: string;
+}
+
+export function DecisionSlider({
+  id,
+  label,
+  value,
+  min,
+  max,
+  step = 50,
+  onChange,
+  formatValue = (val) => `$${val.toLocaleString()}`,
+  helperText,
+  focusLabel,
+}: DecisionSliderProps) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <Label htmlFor={id} className="text-sm font-medium text-foreground">
+            {label}
+          </Label>
+          {helperText ? (
+            <p className="text-xs text-muted-foreground leading-relaxed">{helperText}</p>
+          ) : null}
+        </div>
+        <div className="text-right">
+          {focusLabel ? (
+            <p className="text-[11px] uppercase tracking-wide text-primary/70 font-semibold">{focusLabel}</p>
+          ) : null}
+          <p className="text-base font-semibold text-foreground">{formatValue(value)}</p>
+        </div>
+      </div>
+
+      <Slider
+        id={id}
+        value={[value]}
+        min={min}
+        max={max}
+        step={step}
+        onValueChange={(vals) => onChange(vals[0])}
+        className="w-full"
+      />
+
+      <div className="flex justify-between text-xs text-muted-foreground">
+        <span>{formatValue(min)}</span>
+        <span>{formatValue(max)}</span>
+      </div>
+    </div>
+  );
+}
+
+export default DecisionSlider;

--- a/client/src/components/calculators/show-math.tsx
+++ b/client/src/components/calculators/show-math.tsx
@@ -1,0 +1,56 @@
+import GlassCard from "@/components/glass-card";
+
+export interface ShowMathItem {
+  label: string;
+  value: string;
+  helperText?: string;
+  accent?: "muted" | "primary" | "success" | "warning";
+}
+
+interface ShowMathSectionProps {
+  title: string;
+  focusLabel: string;
+  description: string;
+  items: ShowMathItem[];
+}
+
+const accentClasses: Record<NonNullable<ShowMathItem["accent"]>, string> = {
+  muted: "text-muted-foreground",
+  primary: "text-primary",
+  success: "text-emerald-500 dark:text-emerald-400",
+  warning: "text-amber-500 dark:text-amber-400",
+};
+
+export function ShowMathSection({ title, focusLabel, description, items }: ShowMathSectionProps) {
+  return (
+    <GlassCard className="space-y-6">
+      <div>
+        <div className="flex items-center justify-between">
+          <h3 className="text-xl font-semibold text-foreground">{title}</h3>
+          <span className="text-xs font-semibold uppercase tracking-wide text-primary/80">
+            Focus: {focusLabel}
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground mt-2 leading-relaxed">{description}</p>
+      </div>
+
+      <div className="space-y-4">
+        {items.map((item, index) => (
+          <div key={`${item.label}-${index}`} className="border border-border/50 rounded-xl p-4 bg-background/40">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-muted-foreground">{item.label}</span>
+              <span className={`text-base font-semibold ${item.accent ? accentClasses[item.accent] : "text-foreground"}`}>
+                {item.value}
+              </span>
+            </div>
+            {item.helperText ? (
+              <p className="text-xs text-muted-foreground mt-2 leading-relaxed">{item.helperText}</p>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </GlassCard>
+  );
+}
+
+export default ShowMathSection;

--- a/client/src/components/comparisons/hsa-comparison.tsx
+++ b/client/src/components/comparisons/hsa-comparison.tsx
@@ -71,13 +71,14 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
   };
 
   const getLimitText = (inputs: HSAInputs) => {
-    const limit = inputs.accountType === 'hsa' && inputs.coverage === 'family' 
-      ? CONTRIBUTION_LIMITS.HSA_FAMILY 
-      : inputs.accountType === 'fsa' 
-        ? CONTRIBUTION_LIMITS.FSA 
+    const accountType = inputs.accountType ?? 'hsa';
+    const limit = accountType === 'hsa' && inputs.coverage === 'family'
+      ? CONTRIBUTION_LIMITS.HSA_FAMILY
+      : accountType === 'fsa'
+        ? CONTRIBUTION_LIMITS.FSA
         : CONTRIBUTION_LIMITS.HSA_INDIVIDUAL;
-    
-    const accountTypeText = inputs.accountType.toUpperCase();
+
+    const accountTypeText = accountType.toUpperCase();
     const coverageText = inputs.coverage === 'family' ? 'Family' : 'Individual';
     return `2025 ${coverageText} ${accountTypeText} Limit: $${limit.toLocaleString()}`;
   };
@@ -293,11 +294,16 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
               {/* Contribution */}
               <div>
                 <Label className="text-sm font-medium text-foreground mb-2 block">
-                  Annual Contribution: ${scenario.data.contribution.toLocaleString()}
+                  Annual Contribution: ${(
+                    scenario.data.employeeContribution ?? scenario.data.contribution ?? 0
+                  ).toLocaleString()}
                 </Label>
                 <Slider
-                  value={[scenario.data.contribution]}
-                  onValueChange={(value) => updateScenarioInput(scenario.id, 'contribution', value[0])}
+                  value={[scenario.data.employeeContribution ?? scenario.data.contribution ?? 0]}
+                  onValueChange={(value) => {
+                    updateScenarioInput(scenario.id, 'employeeContribution', value[0]);
+                    updateScenarioInput(scenario.id, 'contribution', value[0]);
+                  }}
                   max={contributionLimit}
                   min={0}
                   step={50}

--- a/client/src/components/tooltip.tsx
+++ b/client/src/components/tooltip.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from "react";
 import { Info } from "lucide-react";
 import {
   Tooltip as ShadcnTooltip,
@@ -7,11 +8,12 @@ import {
 import { cn } from "@/lib/utils";
 
 interface TooltipProps {
-  content: string;
+  content: ReactNode;
+  title?: string;
   className?: string;
 }
 
-export default function Tooltip({ content, className }: TooltipProps) {
+export default function Tooltip({ content, title, className }: TooltipProps) {
   return (
     <ShadcnTooltip>
       <TooltipTrigger asChild>
@@ -27,8 +29,11 @@ export default function Tooltip({ content, className }: TooltipProps) {
           <Info className="w-4 h-4" aria-hidden="true" />
         </button>
       </TooltipTrigger>
-      <TooltipContent className="max-w-72 leading-relaxed text-sm" sideOffset={8}>
-        <p>{content}</p>
+      <TooltipContent className="max-w-80 leading-relaxed text-sm" sideOffset={8}>
+        <div className="space-y-1">
+          {title ? <p className="font-semibold text-foreground">{title}</p> : null}
+          <div className="text-muted-foreground [&>p]:mt-0 [&>p]:mb-0">{content}</div>
+        </div>
       </TooltipContent>
     </ShadcnTooltip>
   );

--- a/client/src/lib/benefitFacts.ts
+++ b/client/src/lib/benefitFacts.ts
@@ -1,4 +1,4 @@
-import { CONTRIBUTION_LIMITS } from "@/lib/calculations";
+import { CONTRIBUTION_LIMITS, FSA_LIMITS } from "@/lib/calculations";
 import type { CalculatorId } from "./calculatorTheme";
 
 export interface BenefitFact {
@@ -12,6 +12,10 @@ export const BENEFIT_FACTS: Record<CalculatorId, BenefitFact[]> = {
   hsa: [
     { label: "HSA Individual Limit:", value: formatCurrency(CONTRIBUTION_LIMITS.HSA_INDIVIDUAL) },
     { label: "HSA Family Limit:", value: formatCurrency(CONTRIBUTION_LIMITS.HSA_FAMILY) },
+  ],
+  fsa: [
+    { label: "Health FSA Limit:", value: formatCurrency(CONTRIBUTION_LIMITS.FSA) },
+    { label: "Dependent Care Max:", value: formatCurrency(FSA_LIMITS.dependentCare) },
   ],
   commuter: [
     { label: "Transit Limit:", value: `${formatCurrency(CONTRIBUTION_LIMITS.COMMUTER_TRANSIT)}/month` },

--- a/client/src/lib/calculatorTheme.ts
+++ b/client/src/lib/calculatorTheme.ts
@@ -1,7 +1,8 @@
-export type CalculatorId = "hsa" | "commuter" | "life" | "retirement";
+export type CalculatorId = "hsa" | "fsa" | "commuter" | "life" | "retirement";
 
 export const CALCULATOR_THEME: Record<CalculatorId, { bgClass: string }> = {
   hsa: { bgClass: "bg-[#00768B]" },
+  fsa: { bgClass: "bg-[#6C4CF2]" },
   commuter: { bgClass: "bg-[#26317D]" },
   life: { bgClass: "bg-[#F3716C]" },
   retirement: { bgClass: "bg-[#2B3785]" },

--- a/client/src/lib/pdf/pdf-utils.ts
+++ b/client/src/lib/pdf/pdf-utils.ts
@@ -1,8 +1,19 @@
 import { pdf } from '@react-pdf/renderer';
 import { saveAs } from 'file-saver';
-import { HSAInputs, HSAResults, CommuterInputs, CommuterResults, LifeInsuranceInputs, LifeInsuranceResults, RetirementInputs, RetirementResults } from '@shared/schema';
+import {
+  HSAInputs,
+  HSAResults,
+  FSAInputs,
+  FSAResults,
+  CommuterInputs,
+  CommuterResults,
+  LifeInsuranceInputs,
+  LifeInsuranceResults,
+  RetirementInputs,
+  RetirementResults
+} from '@shared/schema';
 
-export type ReportType = 'hsa' | 'commuter' | 'life-insurance' | 'retirement' | 'comparison';
+export type ReportType = 'hsa' | 'fsa' | 'commuter' | 'life-insurance' | 'retirement' | 'comparison';
 
 export interface PDFReportData {
   type: ReportType;

--- a/client/src/lib/pdf/templates/comparison-report.tsx
+++ b/client/src/lib/pdf/templates/comparison-report.tsx
@@ -70,11 +70,11 @@ export const ComparisonReport: React.FC<ComparisonReportProps> = ({ data }) => {
                 <Text style={{ fontSize: 11, fontWeight: 'bold', marginBottom: 5, color: '#1f2937' }}>
                   {scenario.name}
                 </Text>
-                <ValueRow label="Account Type" value={scenario.inputs.accountType.toUpperCase()} />
+                <ValueRow label="Account Type" value={(scenario.inputs.accountType ?? 'hsa').toUpperCase()} />
                 <ValueRow label="Coverage" value={scenario.inputs.coverage === 'family' ? 'Family' : 'Individual'} />
-                <ValueRow label="Annual Contribution" value={hsaResults.actualContribution} currency />
+                <ValueRow label="Annual Contribution" value={hsaResults.totalContribution ?? hsaResults.actualContribution ?? 0} currency />
                 <ValueRow label="Tax Savings" value={hsaResults.taxSavings} currency success />
-                <ValueRow label="Effective Cost" value={hsaResults.effectiveCost} currency primary />
+                <ValueRow label="Effective Cost" value={hsaResults.effectiveCost ?? 0} currency primary />
               </View>
             );
           })}

--- a/client/src/lib/pdf/templates/fsa-report.tsx
+++ b/client/src/lib/pdf/templates/fsa-report.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Text } from '@react-pdf/renderer';
+import { BaseDocument } from '../components/base-document';
+import { Section, ValueRow, MetricCard, MetricGrid, Divider, Note } from '../components/pdf-sections';
+import { formatCurrency, PDFReportData } from '../pdf-utils';
+import { FSAInputs, FSAResults } from '@shared/schema';
+
+interface FSAReportProps {
+  data: PDFReportData & {
+    inputs: FSAInputs;
+    results: FSAResults;
+  };
+}
+
+export const FSAReport: React.FC<FSAReportProps> = ({ data }) => {
+  const { inputs, results, generatedAt } = data;
+
+  return (
+    <BaseDocument title="FSA Election Analysis" subtitle="Health & Dependent Care FSAs - Tax Year 2025" generatedAt={generatedAt}>
+      <Section title="Executive Summary">
+        <MetricGrid>
+          <MetricCard
+            title="Health FSA Election"
+            value={inputs.healthElection}
+            currency
+            description="Total annual amount elected"
+          />
+          <MetricCard
+            title="Expected Utilisation"
+            value={results.expectedUtilization}
+            currency
+            description="Projected spend within plan rules"
+          />
+          <MetricCard
+            title="Tax Savings"
+            value={results.taxSavings}
+            currency
+            description="Payroll tax reduction"
+          />
+          <MetricCard
+            title="Forfeiture Risk"
+            value={results.forfeitureRisk}
+            currency
+            description="Potential unused balance"
+          />
+        </MetricGrid>
+      </Section>
+
+      <Divider />
+
+      <Section title="Plan Inputs">
+        <ValueRow label="Health FSA Election" value={inputs.healthElection} currency />
+        <ValueRow label="Expected Eligible Expenses" value={inputs.expectedEligibleExpenses} currency />
+        <ValueRow label="Carryover Allowance" value={inputs.planCarryover} currency />
+        <ValueRow label="Grace Period" value={`${inputs.gracePeriodMonths.toFixed(1)} months`} />
+        <ValueRow label="Marginal Tax Rate" value={`${inputs.taxBracket}%`} />
+        <ValueRow label="Dependent-care Included" value={inputs.includeDependentCare ? 'Yes' : 'No'} />
+        {inputs.includeDependentCare ? (
+          <>
+            <ValueRow label="Dependent-care Election" value={inputs.dependentCareElection} currency />
+            <ValueRow label="Expected Dependent-care Expenses" value={inputs.expectedDependentCareExpenses} currency />
+          </>
+        ) : null}
+      </Section>
+
+      <Divider />
+
+      <Section title="Health FSA Forecast">
+        <Text style={{ fontSize: 10, marginBottom: 10, color: '#374151' }}>
+          Health FSA dollars are available at the start of the plan year. Align your election with known procedures and
+          everyday copays to minimise forfeiture risk.
+        </Text>
+        <ValueRow label="Election vs. Expected Spend" value={`${formatCurrency(inputs.healthElection)} / ${formatCurrency(inputs.expectedEligibleExpenses)}`} />
+        <ValueRow label="Carryover Protected" value={results.carryoverProtected} currency />
+        <ValueRow label="Potential Forfeiture" value={results.forfeitureRisk} currency highlight />
+        <ValueRow label="Net Benefit (Tax Savings − Risk)" value={results.netBenefit} currency primary />
+      </Section>
+
+      <Divider />
+
+      {inputs.includeDependentCare ? (
+        <Section title="Dependent-care FSA Snapshot">
+          <ValueRow label="Election" value={inputs.dependentCareElection} currency />
+          <ValueRow label="Expected Expenses" value={inputs.expectedDependentCareExpenses} currency />
+          <ValueRow label="Tax Savings" value={results.dependentCareTaxSavings} currency />
+          <ValueRow label="Potential Forfeiture" value={results.dependentCareForfeitureRisk} currency highlight />
+          <Note>
+            Dependent-care FSAs reimburse as you contribute. Submit receipts regularly to avoid leaving reimbursements on
+            the table, and coordinate with your spouse so household elections stay within IRS limits.
+          </Note>
+        </Section>
+      ) : null}
+
+      <Divider />
+
+      <Section title="Recommendations">
+        <Text style={{ fontSize: 10, marginBottom: 6, color: '#374151' }}>
+          Use these suggestions to fine-tune your election and stay aligned with plan rules:
+        </Text>
+        <Text style={{ fontSize: 9, marginBottom: 4, color: '#374151' }}>
+          • If expected expenses are lower than your election, reduce the election or plan eligible purchases before the
+          year closes.
+        </Text>
+        <Text style={{ fontSize: 9, marginBottom: 4, color: '#374151' }}>
+          • Track reimbursements throughout the year to keep cash flowing and avoid a rush during the grace period.
+        </Text>
+        <Text style={{ fontSize: 9, color: '#374151' }}>
+          • Coordinate health FSAs with HSAs or copay-based plans—only one spouse can elect a full health FSA if the other
+          contributes to an HSA.
+        </Text>
+      </Section>
+    </BaseDocument>
+  );
+};
+
+export default FSAReport;

--- a/client/src/lib/pdf/templates/hsa-report.tsx
+++ b/client/src/lib/pdf/templates/hsa-report.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Text, View } from '@react-pdf/renderer';
+import { Text } from '@react-pdf/renderer';
 import { BaseDocument } from '../components/base-document';
 import { Section, ValueRow, MetricCard, MetricGrid, Divider, Note } from '../components/pdf-sections';
-import { formatCurrency, formatPercentage, PDFReportData } from '../pdf-utils';
+import { formatCurrency, PDFReportData } from '../pdf-utils';
 import { HSAInputs, HSAResults } from '@shared/schema';
 
 interface HSAReportProps {
@@ -14,188 +14,100 @@ interface HSAReportProps {
 
 export const HSAReport: React.FC<HSAReportProps> = ({ data }) => {
   const { inputs, results, generatedAt } = data;
-  
-  const accountTypeText = inputs.accountType.toUpperCase();
   const coverageText = inputs.coverage === 'family' ? 'Family' : 'Individual';
-  
+
   return (
-    <BaseDocument
-      title={`${accountTypeText} Benefits Analysis Report`}
-      subtitle={`${coverageText} Coverage - Tax Year 2025`}
-      generatedAt={generatedAt}
-    >
-      {/* Executive Summary */}
+    <BaseDocument title="HSA Strategy Analysis" subtitle={`${coverageText} HDHP Coverage - Tax Year 2025`} generatedAt={generatedAt}>
       <Section title="Executive Summary">
         <MetricGrid>
           <MetricCard
-            title="Annual Tax Savings"
+            title="Annual Premium Savings"
+            value={results.annualPremiumSavings}
+            currency
+            description="Budget freed by choosing the HDHP"
+          />
+          <MetricCard
+            title="Tax Savings"
             value={results.taxSavings}
             currency
-            description="Pre-tax benefit reduction"
+            description="Pre-tax payroll reduction"
           />
           <MetricCard
-            title="Effective Cost"
-            value={results.effectiveCost}
+            title="Total HSA Funding"
+            value={results.totalContribution}
             currency
-            description="After-tax contribution cost"
+            description="Employee and employer dollars combined"
           />
           <MetricCard
-            title="Annual Contribution"
-            value={results.actualContribution}
+            title="Net Cashflow Advantage"
+            value={results.netCashflowAdvantage}
             currency
-            description="Applied to account"
-          />
-          <MetricCard
-            title="Savings Rate"
-            value={(results.taxSavings / results.actualContribution) * 100}
-            percentage
-            description="Tax savings percentage"
+            description="Premium gap + seed + tax savings − payroll"
           />
         </MetricGrid>
       </Section>
 
       <Divider />
 
-      {/* Account Configuration */}
-      <Section title="Account Configuration">
-        <ValueRow label="Account Type" value={accountTypeText} />
+      <Section title="HDHP & Contribution Details">
         <ValueRow label="Coverage Level" value={coverageText} />
-        <ValueRow label="Annual Income" value={inputs.income} currency />
-        <ValueRow label="Tax Bracket" value={`${inputs.taxBracket}%`} />
-        <ValueRow 
-          label="2025 Contribution Limit" 
-          value={results.contributionLimit} 
-          currency 
-          highlight 
-        />
+        <ValueRow label="Participant Age" value={inputs.age} />
+        <ValueRow label="Marginal Tax Rate" value={`${inputs.taxBracket}%`} />
+        <ValueRow label="2025 Contribution Limit" value={results.annualContributionLimit} currency highlight />
+        <ValueRow label="Employee Contribution" value={results.employeeContribution} currency />
+        <ValueRow label="Employer Contribution" value={results.employerContribution} currency />
+        <ValueRow label="Target Reserve" value={inputs.targetReserve} currency />
       </Section>
 
       <Divider />
 
-      {/* Detailed Calculations */}
-      <Section title="Tax Benefit Calculations">
+      <Section title="Premium Comparison & Cashflow">
         <Text style={{ fontSize: 10, marginBottom: 10, color: '#374151' }}>
-          This section shows how your {accountTypeText} contribution reduces your taxable income and saves on taxes.
+          HDHPs swap predictable copays for lower premiums. Redirect the premium gap and tax savings into the HSA so the
+          deductible is covered when claims arrive.
         </Text>
-        
-        <ValueRow label="Desired Annual Contribution" value={inputs.contribution} currency />
-        <ValueRow label="Maximum Allowed (2025)" value={results.contributionLimit} currency />
-        <ValueRow 
-          label="Actual Contribution" 
-          value={results.actualContribution} 
-          currency 
-          primary 
-        />
-        
-        <View style={{ marginVertical: 10 }}>
-          <Text style={{ fontSize: 9, color: '#6b7280', marginBottom: 5 }}>Tax Impact:</Text>
-          <ValueRow label="Gross Income" value={inputs.income} currency />
-          <ValueRow label="Less: Pre-tax Contribution" value={`-${formatCurrency(results.actualContribution)}`} />
-          <ValueRow 
-            label="Taxable Income" 
-            value={results.taxableIncome} 
-            currency 
-            highlight 
-          />
-          <ValueRow 
-            label="Tax Savings ({inputs.taxBracket}%)" 
-            value={results.taxSavings} 
-            currency 
-            success 
-          />
-        </View>
-
-        <ValueRow 
-          label="Your Effective Cost" 
-          value={results.effectiveCost} 
-          currency 
-          highlight 
-          primary 
-        />
+        <ValueRow label="HDHP Monthly Premium" value={inputs.hdhpMonthlyPremium} currency />
+        <ValueRow label="Alternative Plan Premium" value={inputs.altPlanMonthlyPremium} currency />
+        <ValueRow label="Annual Premium Savings" value={results.annualPremiumSavings} currency primary />
+        <ValueRow label="Tax Savings" value={results.taxSavings} currency />
+        <ValueRow label="Employer Seed" value={results.employerContribution} currency />
+        <ValueRow label="Net Cashflow Advantage" value={results.netCashflowAdvantage} currency highlight />
       </Section>
 
       <Divider />
 
-      {/* Account Type Benefits */}
-      <Section title={`${accountTypeText} Key Benefits`}>
-        {inputs.accountType === 'hsa' ? (
-          <View>
-            <Text style={{ fontSize: 10, marginBottom: 8, color: '#374151' }}>
-              Health Savings Accounts offer triple tax advantages:
-            </Text>
-            <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-              • Tax-deductible contributions reduce current taxable income
-            </Text>
-            <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-              • Tax-free growth on investments within the account
-            </Text>
-            <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-              • Tax-free withdrawals for qualified medical expenses
-            </Text>
-            <Text style={{ fontSize: 9, marginBottom: 8, color: '#374151' }}>
-              • After age 65: penalty-free withdrawals for any purpose (taxed as income)
-            </Text>
-            <Note>
-              HSA requires enrollment in a High Deductible Health Plan (HDHP). 
-              Unused funds roll over annually with no "use it or lose it" provision.
-            </Note>
-          </View>
-        ) : (
-          <View>
-            <Text style={{ fontSize: 10, marginBottom: 8, color: '#374151' }}>
-              Flexible Spending Accounts provide immediate tax savings:
-            </Text>
-            <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-              • Pre-tax payroll deductions reduce current taxable income
-            </Text>
-            <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-              • Full annual amount available at plan year start
-            </Text>
-            <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-              • Wide range of eligible medical and dependent care expenses
-            </Text>
-            <Text style={{ fontSize: 9, marginBottom: 8, color: '#374151' }}>
-              • Lower contribution limit than HSA but immediate access
-            </Text>
-            <Note>
-              FSA follows "use it or lose it" rules. Plan carefully to avoid losing unused funds. 
-              Some plans offer a grace period or small carryover amount.
-            </Note>
-          </View>
-        )}
+      <Section title="HSA Reserve Outlook">
+        <ValueRow label="Projected Reserve" value={results.projectedReserve} currency primary />
+        <ValueRow label="Target Reserve" value={inputs.targetReserve} currency />
+        <ValueRow label="Reserve Shortfall" value={results.reserveShortfall} currency highlight />
+        <Note>
+          HDHPs depend on a stocked HSA to offset surprise bills. Direct premium savings into the account until the reserve
+          matches your deductible, then invest additional dollars for future medical needs.
+        </Note>
       </Section>
 
       <Divider />
 
-      {/* Recommendations */}
       <Section title="Recommendations">
-        <Text style={{ fontSize: 10, marginBottom: 8, color: '#374151' }}>
-          Based on your inputs, here are optimization strategies:
+        <Text style={{ fontSize: 10, marginBottom: 6, color: '#374151' }}>
+          Use these suggestions to keep your HDHP affordable and resilient:
         </Text>
-        
-        {results.actualContribution < results.contributionLimit && (
-          <Text style={{ fontSize: 9, marginBottom: 5, color: '#374151' }}>
-            • Consider increasing your contribution to maximize tax savings. 
-            Additional {formatCurrency(results.contributionLimit - results.actualContribution)} could 
-            save approximately {formatCurrency((results.contributionLimit - results.actualContribution) * (inputs.taxBracket / 100))} 
-            in taxes.
-          </Text>
-        )}
-        
-        {inputs.accountType === 'hsa' && (
-          <Text style={{ fontSize: 9, marginBottom: 5, color: '#374151' }}>
-            • Consider investing HSA funds for long-term growth if you have adequate cash reserves for current medical expenses.
-          </Text>
-        )}
-        
-        <Text style={{ fontSize: 9, marginBottom: 5, color: '#374151' }}>
-          • Keep records of all qualified expenses for tax purposes and potential audits.
+        <Text style={{ fontSize: 9, marginBottom: 4, color: '#374151' }}>
+          • Set aside at least {formatCurrency(results.annualPremiumSavings / 12)} each month—the premium gap that should flow
+          straight into the HSA.
         </Text>
-        
+        <Text style={{ fontSize: 9, marginBottom: 4, color: '#374151' }}>
+          • Revisit contributions mid-year if your HSA balance trails the target reserve after major claims.
+        </Text>
+        <Text style={{ fontSize: 9, marginBottom: 4, color: '#374151' }}>
+          • Once the reserve is fully funded, consider investing future HSA dollars for long-term growth.
+        </Text>
         <Text style={{ fontSize: 9, color: '#374151' }}>
-          • Review your contribution amount annually as income and tax brackets may change.
+          • Keep receipts for qualified expenses so you can reimburse yourself later or document withdrawals for the IRS.
         </Text>
       </Section>
     </BaseDocument>
   );
 };
+
+export default HSAReport;

--- a/client/src/pages/calculator-hub.tsx
+++ b/client/src/pages/calculator-hub.tsx
@@ -1,4 +1,4 @@
-import { HeartPulse, Bus, Shield, TrendingUp } from "lucide-react";
+import { HeartPulse, ClipboardList, Bus, Shield, TrendingUp } from "lucide-react";
 import GlassCard from "@/components/glass-card";
 import { useLocation } from "wouter";
 import { CALCULATOR_THEME, type CalculatorId } from "@/lib/calculatorTheme";
@@ -16,10 +16,17 @@ export default function CalculatorHub() {
   }> = [
     {
       id: "hsa",
-      title: "HSA/FSA Calculator",
-      description: "Calculate your health savings and flexible spending account benefits with 2025 contribution limits.",
+      title: "HSA Strategy Planner",
+      description: "Plan HDHP premium savings, employer seed money, and deductible reserves for your HSA.",
       icon: HeartPulse,
       route: "/hsa",
+    },
+    {
+      id: "fsa",
+      title: "FSA Election Forecaster",
+      description: "Project healthcare and dependent-care expenses to choose confident FSA elections.",
+      icon: ClipboardList,
+      route: "/fsa",
     },
     {
       id: "commuter",

--- a/client/src/pages/comparison-tool.tsx
+++ b/client/src/pages/comparison-tool.tsx
@@ -37,9 +37,9 @@ const normaliseCalculatorId = (id: CalculatorType): CalculatorId => {
 const calculatorTypes = [
   {
     id: 'hsa' as const,
-    name: 'HSA/FSA Benefits',
+    name: 'HSA Strategy',
     icon: HeartPulse,
-    description: 'Compare health savings and flexible spending account scenarios'
+    description: 'Compare HDHP premium savings and HSA reserve strategies'
   },
   {
     id: 'commuter' as const,
@@ -98,8 +98,14 @@ export default function ComparisonTool() {
         return {
           accountType: 'hsa',
           coverage: 'individual',
+          age: 40,
           income: 75000,
           contribution: 3000,
+          employeeContribution: 3000,
+          hdhpMonthlyPremium: 320,
+          altPlanMonthlyPremium: 520,
+          employerSeed: 500,
+          targetReserve: 4000,
           taxBracket: 22
         };
       case 'commuter':

--- a/client/src/pages/fsa-calculator.tsx
+++ b/client/src/pages/fsa-calculator.tsx
@@ -1,0 +1,358 @@
+import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, ClipboardList, Download, Wallet } from "lucide-react";
+import { useLocation } from "wouter";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import GlassCard from "@/components/glass-card";
+import Tooltip from "@/components/tooltip";
+import DecisionSlider from "@/components/calculators/decision-slider";
+import ShowMathSection from "@/components/calculators/show-math";
+import { calculateFSA, FSA_LIMITS } from "@/lib/calculations";
+import { FSAInputs, FSAResults } from "@shared/schema";
+import { usePDFExport } from "@/lib/pdf/use-pdf-export";
+
+const DEFAULT_INPUTS: FSAInputs = {
+  healthElection: 2600,
+  expectedEligibleExpenses: 2400,
+  planCarryover: 640,
+  gracePeriodMonths: 2,
+  includeDependentCare: true,
+  dependentCareElection: 4000,
+  expectedDependentCareExpenses: 3600,
+  taxBracket: 22,
+};
+
+const currency = (value: number) => `$${Math.round(value).toLocaleString()}`;
+
+export default function FSACalculator() {
+  const [, navigate] = useLocation();
+  const { exportFSAReport, isGenerating, error } = usePDFExport();
+
+  const [inputs, setInputs] = useState<FSAInputs>(DEFAULT_INPUTS);
+  const [results, setResults] = useState<FSAResults>(() => calculateFSA(DEFAULT_INPUTS));
+
+  useEffect(() => {
+    setResults(calculateFSA(inputs));
+  }, [inputs]);
+
+  const carryoverCeiling = useMemo(() => Math.min(inputs.planCarryover, inputs.healthElection), [inputs.planCarryover, inputs.healthElection]);
+
+  const updateInput = <K extends keyof FSAInputs>(key: K, value: FSAInputs[K]) => {
+    setInputs(prev => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between mb-8">
+        <div className="flex items-center space-x-4">
+          <Button
+            variant="ghost"
+            className="glass-effect p-3 rounded-xl hover:bg-muted transition-colors"
+            onClick={() => navigate("/")}
+            data-testid="button-back"
+          >
+            <ArrowLeft className="text-foreground" />
+          </Button>
+          <div>
+            <h2 className="text-3xl font-bold text-foreground" data-testid="text-page-title">
+              FSA Election Forecaster
+            </h2>
+            <p className="text-muted-foreground max-w-xl">
+              Forecast medical and dependent-care expenses so you can elect the right FSA amounts. FSAs give you the
+              full-year election on day one, but unused dollars are forfeited—pair the upfront access with realistic
+              expense planning.
+            </p>
+          </div>
+        </div>
+        <div className="text-right">
+          <p className="text-sm text-muted-foreground">Updated for 2025</p>
+          <p className="text-xs text-muted-foreground">IRS Notice 2024-87</p>
+        </div>
+      </div>
+
+      <div className="grid lg:grid-cols-3 gap-8">
+        <div className="lg:col-span-2 space-y-8">
+          <GlassCard className="space-y-6">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-xl font-semibold text-foreground">Plan-year blueprint</h3>
+                <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
+                  Choose how much to lock into your health FSA and map out when those dollars will be needed. Because the
+                  entire election is available on the first day of the plan year, align your forecast with surgeries,
+                  pregnancies, therapy, or prescriptions you know are coming.
+                </p>
+              </div>
+              <Tooltip
+                title="Front-loaded access"
+                content={
+                  <p>
+                    Health FSA elections are front-loaded—you can spend the full annual amount early in the plan year even
+                    though you have only contributed a few pay periods. Plan for that float while keeping forfeiture risk in
+                    check.
+                  </p>
+                }
+              />
+            </div>
+
+            <DecisionSlider
+              id="health-election"
+              label="Health FSA election"
+              value={inputs.healthElection}
+              min={0}
+              max={FSA_LIMITS.health}
+              step={50}
+              onChange={(value) => updateInput("healthElection", value)}
+              helperText={`The IRS cap for 2025 is ${currency(FSA_LIMITS.health)}. Elect only what you expect to use within the plan year.`}
+              focusLabel="Project annual spend"
+            />
+
+            <div className="grid md:grid-cols-2 gap-6">
+              <div>
+                <Label htmlFor="expected-expenses" className="text-sm font-medium text-foreground mb-2">
+                  Expected eligible expenses
+                </Label>
+                <Input
+                  id="expected-expenses"
+                  type="number"
+                  min={0}
+                  value={inputs.expectedEligibleExpenses}
+                  onChange={(event) => updateInput("expectedEligibleExpenses", Number(event.target.value) || 0)}
+                />
+                <p className="text-xs text-muted-foreground mt-2">
+                  Add up copays, deductibles, glasses, dental work—anything your health plan does not fully cover.
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                <div>
+                  <Label htmlFor="tax-rate" className="text-sm font-medium text-foreground mb-2">
+                    Marginal tax rate (%)
+                  </Label>
+                  <Input
+                    id="tax-rate"
+                    type="number"
+                    min={0}
+                    max={50}
+                    value={inputs.taxBracket}
+                    onChange={(event) => updateInput("taxBracket", Number(event.target.value) || 0)}
+                  />
+                </div>
+
+                <div>
+                  <Label className="text-sm font-medium text-foreground mb-2">Carryover or grace period</Label>
+                  <div className="space-y-3 rounded-xl border border-border/60 p-4">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-muted-foreground">Carryover allowance</span>
+                      <span className="font-semibold text-foreground">{currency(carryoverCeiling)}</span>
+                    </div>
+                    <Input
+                      type="number"
+                      min={0}
+                      max={FSA_LIMITS.health}
+                      value={inputs.planCarryover}
+                      onChange={(event) => updateInput("planCarryover", Number(event.target.value) || 0)}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Enter your plan's carryover allowance. If you have a grace period instead, set carryover to 0 and use
+                      the months slider below.
+                    </p>
+                    <DecisionSlider
+                      id="grace-period"
+                      label="Grace period length"
+                      value={inputs.gracePeriodMonths}
+                      min={0}
+                      max={3}
+                      step={0.5}
+                      formatValue={(value) => `${value.toFixed(1)} months`}
+                      onChange={(value) => updateInput("gracePeriodMonths", value)}
+                      helperText="How long after the plan year ends you can spend leftover dollars on prior-year expenses."
+                      focusLabel="Plan-year timing"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </GlassCard>
+
+          <GlassCard className="space-y-6">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-xl font-semibold text-foreground">Dependent-care coordination</h3>
+                <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
+                  If you have daycare, after-school, or elder-care bills, coordinate the dependent-care FSA alongside the
+                  medical FSA. The benefit is capped separately and follows the same use-it-or-lose-it rules.
+                </p>
+              </div>
+              <Tooltip
+                title="Limits work differently"
+                content={
+                  <p>
+                    Dependent-care FSA dollars are shared per household and capped at {currency(FSA_LIMITS.dependentCare)}.
+                    Elections are not available upfront—funds accumulate as you contribute through payroll.
+                  </p>
+                }
+              />
+            </div>
+
+            <div className="flex items-center justify-between rounded-xl border border-border/60 p-4">
+              <div>
+                <p className="text-sm font-medium text-foreground">Include dependent-care FSA</p>
+                <p className="text-xs text-muted-foreground">
+                  Toggle on if you plan to set aside pre-tax dollars for child or elder care expenses.
+                </p>
+              </div>
+              <Switch
+                checked={inputs.includeDependentCare}
+                onCheckedChange={(checked) => updateInput("includeDependentCare", checked)}
+              />
+            </div>
+
+            {inputs.includeDependentCare ? (
+              <div className="grid md:grid-cols-2 gap-6">
+                <div>
+                  <DecisionSlider
+                    id="dependent-care-election"
+                    label="Dependent-care election"
+                    value={inputs.dependentCareElection}
+                    min={0}
+                    max={FSA_LIMITS.dependentCare}
+                    step={100}
+                    onChange={(value) => updateInput("dependentCareElection", value)}
+                    helperText={`Household maximum is ${currency(FSA_LIMITS.dependentCare)} per year.`}
+                    focusLabel="Align with invoices"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="dependent-care-expenses" className="text-sm font-medium text-foreground mb-2">
+                    Expected dependent-care expenses
+                  </Label>
+                  <Input
+                    id="dependent-care-expenses"
+                    type="number"
+                    min={0}
+                    value={inputs.expectedDependentCareExpenses}
+                    onChange={(event) => updateInput("expectedDependentCareExpenses", Number(event.target.value) || 0)}
+                  />
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Include daycare, preschool, or qualified elder care costs you expect this year.
+                  </p>
+                </div>
+              </div>
+            ) : null}
+          </GlassCard>
+        </div>
+
+        <div className="space-y-8">
+          <GlassCard className="space-y-6">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xl font-semibold text-foreground">FSA decision dashboard</h3>
+              <Wallet className="text-primary" />
+            </div>
+            <div className="space-y-4">
+              <div className="rounded-xl border border-primary/30 bg-primary/5 p-4">
+                <p className="text-sm text-muted-foreground">Health FSA tax savings</p>
+                <p className="text-2xl font-bold text-primary">{currency(results.taxSavings)}</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Immediate payroll tax reduction from your health FSA election.
+                </p>
+              </div>
+              <div className="rounded-xl border border-emerald-300/40 bg-emerald-500/10 p-4">
+                <p className="text-sm text-muted-foreground">Protected by carryover/grace</p>
+                <p className="text-2xl font-bold text-emerald-500">{currency(results.carryoverProtected)}</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Amount likely saved from forfeiture thanks to your plan's safety net.
+                </p>
+              </div>
+              <div className="rounded-xl border border-amber-300/40 bg-amber-500/10 p-4">
+                <p className="text-sm text-muted-foreground">Potential forfeiture risk</p>
+                <p className="text-2xl font-bold text-amber-500">{currency(results.forfeitureRisk)}</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Dollars at risk if spending runs below your election after grace/carryover buffers.
+                </p>
+              </div>
+              {inputs.includeDependentCare ? (
+                <div className="rounded-xl border border-border p-4">
+                  <p className="text-sm text-muted-foreground">Dependent-care tax savings</p>
+                  <p className="text-2xl font-bold text-foreground">{currency(results.dependentCareTaxSavings)}</p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Withheld pre-tax to offset childcare or elder care invoices.
+                  </p>
+                </div>
+              ) : null}
+            </div>
+
+            <Button
+              className="w-full"
+              size="lg"
+              onClick={() => exportFSAReport(inputs, results)}
+              disabled={isGenerating}
+            >
+              <Download className="mr-2 h-4 w-4" />
+              {isGenerating ? "Generating report..." : "Download FSA report"}
+            </Button>
+            {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          </GlassCard>
+
+          <ShowMathSection
+            title="Show the math"
+            focusLabel="Forecast vs. IRS limits"
+            description="Compare what you plan to spend with what you elected so you can avoid forfeiting dollars while still enjoying the front-loaded access an FSA provides."
+            items={[
+              {
+                label: "Health FSA election vs. forecast",
+                value: `${currency(inputs.healthElection)} elected / ${currency(inputs.expectedEligibleExpenses)} planned`,
+                helperText:
+                  results.expectedUtilization < inputs.healthElection
+                    ? `${currency(inputs.healthElection - results.expectedUtilization)} may go unused unless carryover or a grace period saves it.`
+                    : "Your election matches the care you expect to receive—low forfeiture risk.",
+                accent: results.expectedUtilization < inputs.healthElection ? "warning" : "success",
+              },
+              {
+                label: "Carryover + grace coverage",
+                value: `${currency(results.carryoverProtected)} protected`,
+                helperText: "Set expectations for how much of any leftover funds your plan rules will allow you to keep.",
+                accent: "primary",
+              },
+              {
+                label: "Net benefit after forfeiture",
+                value: currency(results.netBenefit),
+                helperText:
+                  results.netBenefit >= 0
+                    ? "Positive numbers mean tax savings outpace potential forfeitures."
+                    : "If the number is negative, trim your election or accelerate eligible spending.",
+                accent: results.netBenefit >= 0 ? "success" : "warning",
+              },
+              ...(inputs.includeDependentCare
+                ? ([
+                    {
+                      label: "Dependent-care election vs. bills",
+                      value: `${currency(inputs.dependentCareElection)} elected / ${currency(inputs.expectedDependentCareExpenses)} planned`,
+                      helperText:
+                        results.dependentCareForfeitureRisk > 0
+                          ? `${currency(results.dependentCareForfeitureRisk)} could be forfeited—double-check invoices or reduce the election.`
+                          : "Your dependent-care election is covered by expected expenses.",
+                      accent: results.dependentCareForfeitureRisk > 0 ? "warning" : "success",
+                    },
+                  ] as const)
+                : []),
+            ]}
+          />
+
+          <GlassCard className="space-y-4">
+            <div className="flex items-center gap-3 text-primary">
+              <ClipboardList className="h-5 w-5" />
+              <h3 className="text-lg font-semibold text-foreground">Coordinate with your health plan</h3>
+            </div>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              FSAs pair best with copay-based medical plans or HDHPs where you limit contributions. Track reimbursements
+              through the year so you do not leave money in the account at year end, and revisit elections if your plan
+              switches between carryover and grace period provisions.
+            </p>
+          </GlassCard>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- split the combined HSA/FSA experience into an HSA strategy planner with HDHP context, premium comparisons, funding goals, and refreshed guidance
- add a dedicated FSA election forecaster that captures health and dependent-care forecasts, plan-year timing, and forfeiture safeguards with PDF support
- introduce shared decision slider/show-the-math components, enrich tooltips, and wire HSA/FSA PDF exports and navigation updates

## Testing
- npm run lint
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68d6a36d2a048320bec5a9842859b5f3