### PR TITLE
Add dedicated FSA comparison flows and reporting

### DIFF
--- a/client/src/components/comparisons/fsa-comparison.tsx
+++ b/client/src/components/comparisons/fsa-comparison.tsx
@@ -1,0 +1,440 @@
+import { useEffect, useState } from "react";
+import { Calculator, TrendingDown, TrendingUp, Trash2, AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import GlassCard from "@/components/glass-card";
+import Tooltip from "@/components/tooltip";
+import { calculateFSA, FSA_LIMITS } from "@/lib/calculations";
+import type { FSAInputs, FSAResults } from "@shared/schema";
+
+const currency = (value: number) => `$${Math.round(value).toLocaleString()}`;
+
+type ExpenseBucketKey = "routineCare" | "plannedProcedures" | "pharmacy";
+
+type FSAComparisonInputs = FSAInputs & {
+  expenseBuckets?: Record<ExpenseBucketKey, number>;
+};
+
+interface ScenarioConfig {
+  id: string;
+  name: string;
+  data: FSAComparisonInputs;
+}
+
+interface FSAComparisonProps {
+  scenarios: ScenarioConfig[];
+  onUpdateScenario: (scenarioId: string, data: FSAInputs) => void;
+  onRemoveScenario: (scenarioId: string) => void;
+}
+
+const DEFAULT_BUCKETS: Record<ExpenseBucketKey, number> = {
+  routineCare: 0,
+  plannedProcedures: 0,
+  pharmacy: 0,
+};
+
+export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveScenario }: FSAComparisonProps) {
+  const [scenarioResults, setScenarioResults] = useState<Record<string, FSAResults>>({});
+
+  useEffect(() => {
+    const computed: Record<string, FSAResults> = {};
+    scenarios.forEach((scenario) => {
+      computed[scenario.id] = calculateFSA(scenario.data);
+    });
+    setScenarioResults(computed);
+  }, [scenarios]);
+
+  const updateScenario = (scenarioId: string, updates: Partial<FSAComparisonInputs>) => {
+    const scenario = scenarios.find((item) => item.id === scenarioId);
+    if (!scenario) return;
+
+    const nextData: FSAComparisonInputs = {
+      ...scenario.data,
+      ...updates,
+    };
+
+    onUpdateScenario(scenarioId, nextData);
+  };
+
+  const updateBucket = (scenarioId: string, bucket: ExpenseBucketKey, value: number) => {
+    const scenario = scenarios.find((item) => item.id === scenarioId);
+    if (!scenario) return;
+
+    const buckets = {
+      ...DEFAULT_BUCKETS,
+      ...scenario.data.expenseBuckets,
+      [bucket]: Math.max(value, 0),
+    };
+
+    const expectedEligibleExpenses = Object.values(buckets).reduce((total, amount) => total + amount, 0);
+
+    const nextData: FSAComparisonInputs = {
+      ...scenario.data,
+      expenseBuckets: buckets,
+      expectedEligibleExpenses,
+    };
+
+    onUpdateScenario(scenarioId, nextData);
+  };
+
+  const getBuckets = (scenario: ScenarioConfig) => ({
+    ...DEFAULT_BUCKETS,
+    ...scenario.data.expenseBuckets,
+  });
+
+  const getMetricIndicator = (value: number, bestValue: number, invert = false) => {
+    const isBest = invert ? value <= bestValue : value >= bestValue;
+    if (isBest) {
+      return <TrendingUp className="text-green-500 ml-2" size={16} />;
+    }
+
+    const Icon = invert ? TrendingUp : TrendingDown;
+    const iconColor = invert ? "text-amber-500" : "text-red-500";
+
+    return <Icon className={`${iconColor} ml-2`} size={16} />;
+  };
+
+  if (scenarios.length === 0) {
+    return (
+      <GlassCard>
+        <div className="text-center py-8">
+          <Calculator className="mx-auto text-muted-foreground mb-4" size={48} />
+          <p className="text-muted-foreground">
+            Add FSA scenarios above to compare elections, grace periods, and forfeiture risk.
+          </p>
+        </div>
+      </GlassCard>
+    );
+  }
+
+  const summaryMetrics = scenarios.map((scenario) => {
+    const results = scenarioResults[scenario.id];
+    return {
+      id: scenario.id,
+      name: scenario.name,
+      expectedUtilization: results?.expectedUtilization ?? 0,
+      carryoverProtected: results?.carryoverProtected ?? 0,
+      forfeitureRisk: results?.forfeitureRisk ?? 0,
+      netBenefit: results?.netBenefit ?? 0,
+      taxSavings: results?.taxSavings ?? 0,
+      healthElection: scenario.data.healthElection,
+    };
+  });
+
+  const bestExpectedUtilization = Math.max(...summaryMetrics.map((metric) => metric.expectedUtilization));
+  const bestCarryover = Math.max(...summaryMetrics.map((metric) => metric.carryoverProtected));
+  const lowestForfeiture = Math.min(...summaryMetrics.map((metric) => metric.forfeitureRisk));
+  const bestNetBenefit = Math.max(...summaryMetrics.map((metric) => metric.netBenefit));
+
+  return (
+    <div className="space-y-8">
+      <GlassCard>
+        <h3 className="text-lg font-semibold text-foreground mb-6">FSA Scenario Summary</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left p-3 font-medium text-muted-foreground">Metric</th>
+                {summaryMetrics.map((metric) => (
+                  <th key={metric.id} className="text-center p-3 font-medium text-foreground">
+                    {metric.name}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-border">
+                <td className="p-3 font-medium text-foreground">Health FSA Election</td>
+                {summaryMetrics.map((metric) => (
+                  <td key={`election-${metric.id}`} className="p-3 text-center">
+                    {currency(metric.healthElection)}
+                  </td>
+                ))}
+              </tr>
+              <tr className="border-b border-border">
+                <td className="p-3 font-medium text-foreground">Expected Utilisation</td>
+                {summaryMetrics.map((metric) => (
+                  <td key={`util-${metric.id}`} className="p-3 text-center">
+                    <div className="flex items-center justify-center">
+                      <span className="text-lg font-semibold text-foreground">{currency(metric.expectedUtilization)}</span>
+                      {getMetricIndicator(metric.expectedUtilization, bestExpectedUtilization)}
+                    </div>
+                  </td>
+                ))}
+              </tr>
+              <tr className="border-b border-border">
+                <td className="p-3 font-medium text-foreground">Carryover Utilised</td>
+                {summaryMetrics.map((metric) => (
+                  <td key={`carryover-${metric.id}`} className="p-3 text-center">
+                    <div className="flex items-center justify-center">
+                      <span className="text-lg font-semibold text-primary">{currency(metric.carryoverProtected)}</span>
+                      {getMetricIndicator(metric.carryoverProtected, bestCarryover)}
+                    </div>
+                  </td>
+                ))}
+              </tr>
+              <tr className="border-b border-border">
+                <td className="p-3 font-medium text-foreground">Forfeiture Risk</td>
+                {summaryMetrics.map((metric) => (
+                  <td key={`forfeit-${metric.id}`} className="p-3 text-center">
+                    <div className="flex items-center justify-center">
+                      <span className="text-lg font-semibold text-destructive">{currency(metric.forfeitureRisk)}</span>
+                      {getMetricIndicator(metric.forfeitureRisk, lowestForfeiture, true)}
+                    </div>
+                  </td>
+                ))}
+              </tr>
+              <tr>
+                <td className="p-3 font-medium text-foreground">Net Benefit (Tax Savings − Risk)</td>
+                {summaryMetrics.map((metric) => (
+                  <td key={`benefit-${metric.id}`} className="p-3 text-center">
+                    <div className="flex items-center justify-center">
+                      <span className="text-lg font-semibold text-emerald-600">{currency(metric.netBenefit)}</span>
+                      {getMetricIndicator(metric.netBenefit, bestNetBenefit)}
+                    </div>
+                  </td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </GlassCard>
+
+      <div className="grid gap-6" style={{ gridTemplateColumns: `repeat(${Math.min(scenarios.length, 3)}, 1fr)` }}>
+        {scenarios.map((scenario) => {
+          const results = scenarioResults[scenario.id];
+          const buckets = getBuckets(scenario);
+          const carryoverMax = Math.min(scenario.data.healthElection, FSA_LIMITS.health);
+          const gracePeriodDisplay = `${scenario.data.gracePeriodMonths.toFixed(1)} months`;
+
+          return (
+            <GlassCard key={scenario.id} className="space-y-6" analyticsId={`fsa-scenario-${scenario.id}`}>
+              <div className="flex items-start justify-between border-b border-border pb-2">
+                <div>
+                  <h4 className="text-lg font-semibold text-foreground">{scenario.name}</h4>
+                  <p className="text-xs text-muted-foreground">Plan for eligible expenses and carryover rules</p>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-muted-foreground hover:text-destructive"
+                  onClick={() => onRemoveScenario(scenario.id)}
+                  aria-label={`Remove scenario ${scenario.name}`}
+                >
+                  <Trash2 size={16} />
+                </Button>
+              </div>
+
+              <div className="space-y-5">
+                <div className="rounded-xl border border-border/60 p-4 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-sm font-medium text-foreground">Health FSA election</Label>
+                    <Tooltip
+                      title="Election sizing"
+                      content={
+                        <p>
+                          Align the election with known medical bills. Any dollars beyond carryover and grace-period rules
+                          are forfeited back to the plan.
+                        </p>
+                      }
+                    />
+                  </div>
+                  <Slider
+                    value={[scenario.data.healthElection]}
+                    onValueChange={(value) => updateScenario(scenario.id, { healthElection: value[0] })}
+                    min={0}
+                    max={FSA_LIMITS.health}
+                    step={50}
+                  />
+                  <div className="flex justify-between text-xs text-muted-foreground">
+                    <span>$0</span>
+                    <span>{currency(FSA_LIMITS.health)}</span>
+                  </div>
+                  <div className="text-sm font-semibold text-foreground text-center">
+                    {currency(scenario.data.healthElection)} elected
+                  </div>
+                </div>
+
+                <div className="rounded-xl border border-border/60 p-4 space-y-4">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-sm font-medium text-foreground">Eligible expense buckets</Label>
+                    <Tooltip
+                      title="Track expected spend"
+                      content={
+                        <p>
+                          Break expenses into predictable categories so you can see how much of the election is spoken for
+                          before relying on carryover rules.
+                        </p>
+                      }
+                    />
+                  </div>
+                  <div className="grid gap-3">
+                    <div>
+                      <Label className="text-xs uppercase text-muted-foreground">Routine & preventive care</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={buckets.routineCare}
+                        onChange={(event) => updateBucket(scenario.id, "routineCare", Number(event.target.value) || 0)}
+                      />
+                    </div>
+                    <div>
+                      <Label className="text-xs uppercase text-muted-foreground">Planned procedures</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={buckets.plannedProcedures}
+                        onChange={(event) => updateBucket(scenario.id, "plannedProcedures", Number(event.target.value) || 0)}
+                      />
+                    </div>
+                    <div>
+                      <Label className="text-xs uppercase text-muted-foreground">Prescriptions & therapy</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={buckets.pharmacy}
+                        onChange={(event) => updateBucket(scenario.id, "pharmacy", Number(event.target.value) || 0)}
+                      />
+                    </div>
+                  </div>
+                  <div className="rounded-lg bg-primary/5 border border-dashed border-primary/40 p-3 text-xs text-muted-foreground">
+                    <p>Expected eligible spend: {currency(scenario.data.expectedEligibleExpenses)}</p>
+                    <p>Carryover cushion: {currency(results?.carryoverProtected ?? 0)} • Forfeiture risk: {currency(results?.forfeitureRisk ?? 0)}</p>
+                  </div>
+                </div>
+
+                <div className="rounded-xl border border-border/60 p-4 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-sm font-medium text-foreground">Carryover & grace rules</Label>
+                    <Tooltip
+                      title="Grace period usage"
+                      content={
+                        <p>
+                          Document how long you have to spend remaining dollars after year-end. More time reduces forfeiture
+                          risk if your expenses arrive late.
+                        </p>
+                      }
+                    />
+                  </div>
+                  <div className="grid gap-3">
+                    <div>
+                      <Label className="text-xs uppercase text-muted-foreground">Carryover allowance</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        max={FSA_LIMITS.health}
+                        value={scenario.data.planCarryover}
+                        onChange={(event) => updateScenario(scenario.id, { planCarryover: Number(event.target.value) || 0 })}
+                      />
+                      <p className="text-xs text-muted-foreground mt-1">Up to {currency(carryoverMax)} may roll into the next plan year.</p>
+                    </div>
+                    <div>
+                      <Label className="text-xs uppercase text-muted-foreground">Grace period length</Label>
+                      <Slider
+                        value={[scenario.data.gracePeriodMonths]}
+                        onValueChange={(value) => updateScenario(scenario.id, { gracePeriodMonths: Number(value[0].toFixed(1)) })}
+                        min={0}
+                        max={3}
+                        step={0.5}
+                      />
+                      <div className="flex justify-between text-xs text-muted-foreground">
+                        <span>0 months</span>
+                        <span>3 months</span>
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-1">You have {gracePeriodDisplay} to spend on prior-year expenses.</p>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid gap-4">
+                  <div>
+                    <Label className="text-sm font-medium text-foreground">Marginal tax rate</Label>
+                    <Select
+                      value={scenario.data.taxBracket.toString()}
+                      onValueChange={(value) => updateScenario(scenario.id, { taxBracket: parseFloat(value) })}
+                    >
+                      <SelectTrigger className="glass-input">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="10">10% - Income up to $11,000</SelectItem>
+                        <SelectItem value="12">12% - Income $11,000 - $44,725</SelectItem>
+                        <SelectItem value="22">22% - Income $44,725 - $95,375</SelectItem>
+                        <SelectItem value="24">24% - Income $95,375 - $182,050</SelectItem>
+                        <SelectItem value="32">32% - Income $182,050 - $231,250</SelectItem>
+                        <SelectItem value="35">35% - Income $231,250 - $578,125</SelectItem>
+                        <SelectItem value="37">37% - Income over $578,125</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="rounded-xl border border-border/60 p-4 space-y-3">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <Label className="text-sm font-medium text-foreground">Dependent-care FSA</Label>
+                        <p className="text-xs text-muted-foreground">Payroll reimbursements as expenses occur</p>
+                      </div>
+                      <Switch
+                        checked={scenario.data.includeDependentCare}
+                        onCheckedChange={(checked) =>
+                          updateScenario(scenario.id, {
+                            includeDependentCare: checked,
+                          })
+                        }
+                      />
+                    </div>
+
+                    {scenario.data.includeDependentCare ? (
+                      <div className="grid gap-3">
+                        <div>
+                          <Label className="text-xs uppercase text-muted-foreground">Election amount</Label>
+                          <Input
+                            type="number"
+                            min={0}
+                            max={FSA_LIMITS.dependentCare}
+                            value={scenario.data.dependentCareElection}
+                            onChange={(event) =>
+                              updateScenario(scenario.id, {
+                                dependentCareElection: Number(event.target.value) || 0,
+                              })
+                            }
+                          />
+                        </div>
+                        <div>
+                          <Label className="text-xs uppercase text-muted-foreground">Expected expenses</Label>
+                          <Input
+                            type="number"
+                            min={0}
+                            value={scenario.data.expectedDependentCareExpenses}
+                            onChange={(event) =>
+                              updateScenario(scenario.id, {
+                                expectedDependentCareExpenses: Number(event.target.value) || 0,
+                              })
+                            }
+                          />
+                        </div>
+                        <div className="rounded-lg bg-secondary/10 border border-dashed border-secondary/40 p-3 text-xs text-muted-foreground">
+                          <p>Tax savings: {currency(results?.dependentCareTaxSavings ?? 0)}</p>
+                          <p>Forfeiture risk: {currency(results?.dependentCareForfeitureRisk ?? 0)}</p>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <AlertTriangle size={14} className="text-amber-500" />
+                        <span>Enable dependent-care to compare childcare reimbursements.</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </GlassCard>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/comparisons/hsa-comparison.tsx
+++ b/client/src/components/comparisons/hsa-comparison.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
-import { TrendingUp, TrendingDown, Minus, Calculator, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Calculator, TrendingDown, TrendingUp, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -8,15 +8,8 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Slider } from "@/components/ui/slider";
 import GlassCard from "@/components/glass-card";
 import Tooltip from "@/components/tooltip";
-import { calculateHSA, CONTRIBUTION_LIMITS } from "@/lib/calculations";
-import { HSAInputs, HSAResults } from "@shared/schema";
-
-interface HSAScenario {
-  id: string;
-  name: string;
-  inputs: HSAInputs;
-  results: HSAResults;
-}
+import { calculateHSA, HSA_LIMITS } from "@/lib/calculations";
+import type { HSAInputs, HSAResults } from "@shared/schema";
 
 interface HSAComparisonProps {
   scenarios: Array<{
@@ -28,59 +21,46 @@ interface HSAComparisonProps {
   onRemoveScenario: (scenarioId: string) => void;
 }
 
+const currency = (value: number) => `$${Math.round(value).toLocaleString()}`;
+
 export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveScenario }: HSAComparisonProps) {
   const [scenarioResults, setScenarioResults] = useState<Record<string, HSAResults>>({});
 
-  // Calculate results for all scenarios
   useEffect(() => {
-    const newResults: Record<string, HSAResults> = {};
-    scenarios.forEach(scenario => {
-      newResults[scenario.id] = calculateHSA(scenario.data);
+    const next: Record<string, HSAResults> = {};
+    scenarios.forEach((scenario) => {
+      next[scenario.id] = calculateHSA(scenario.data);
     });
-    setScenarioResults(newResults);
+    setScenarioResults(next);
   }, [scenarios]);
 
-  const updateScenarioInput = (scenarioId: string, key: keyof HSAInputs, value: any) => {
-    const scenario = scenarios.find(s => s.id === scenarioId);
-    if (scenario) {
-      const updatedData = { ...scenario.data, [key]: value };
-      onUpdateScenario(scenarioId, updatedData);
-    }
+  const updateScenario = (scenarioId: string, updates: Partial<HSAInputs>) => {
+    const scenario = scenarios.find((item) => item.id === scenarioId);
+    if (!scenario) return;
+
+    const nextData: HSAInputs = {
+      ...scenario.data,
+      ...updates,
+    };
+
+    onUpdateScenario(scenarioId, nextData);
   };
 
-  const getBestValue = (metric: string, values: number[]) => {
-    switch (metric) {
-      case 'taxSavings':
-      case 'actualContribution':
-        return Math.max(...values);
-      case 'effectiveCost':
-        return Math.min(...values);
-      default:
-        return Math.max(...values);
-    }
+  const getContributionLimit = (inputs: HSAInputs) => {
+    const baseLimit = inputs.coverage === "family" ? HSA_LIMITS.family : HSA_LIMITS.individual;
+    const catchUp = inputs.age >= 55 ? HSA_LIMITS.catchUp : 0;
+    return baseLimit + catchUp;
   };
 
-  const getValueIndicator = (value: number, bestValue: number, metric: string) => {
-    if (value === bestValue) {
+  const getIndicator = (value: number, bestValue: number, invert = false) => {
+    const isBest = invert ? value <= bestValue : value >= bestValue;
+    if (isBest) {
       return <TrendingUp className="text-green-500 ml-2" size={16} />;
     }
-    const isBetter = metric === 'effectiveCost' ? value < bestValue : value > bestValue;
-    return isBetter ? 
-      <TrendingUp className="text-green-500 ml-2" size={16} /> : 
-      <TrendingDown className="text-red-500 ml-2" size={16} />;
-  };
 
-  const getLimitText = (inputs: HSAInputs) => {
-    const accountType = inputs.accountType ?? 'hsa';
-    const limit = accountType === 'hsa' && inputs.coverage === 'family'
-      ? CONTRIBUTION_LIMITS.HSA_FAMILY
-      : accountType === 'fsa'
-        ? CONTRIBUTION_LIMITS.FSA
-        : CONTRIBUTION_LIMITS.HSA_INDIVIDUAL;
-
-    const accountTypeText = accountType.toUpperCase();
-    const coverageText = inputs.coverage === 'family' ? 'Family' : 'Individual';
-    return `2025 ${coverageText} ${accountTypeText} Limit: $${limit.toLocaleString()}`;
+    const Icon = invert ? TrendingUp : TrendingDown;
+    const color = invert ? "text-amber-500" : "text-red-500";
+    return <Icon className={`${color} ml-2`} size={16} />;
   };
 
   if (scenarios.length === 0) {
@@ -88,32 +68,43 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
       <GlassCard>
         <div className="text-center py-8">
           <Calculator className="mx-auto text-muted-foreground mb-4" size={48} />
-          <p className="text-muted-foreground">Add scenarios above to start comparing HSA/FSA benefits.</p>
+          <p className="text-muted-foreground">Add HSA scenarios above to analyse premium savings and deductible exposure.</p>
         </div>
       </GlassCard>
     );
   }
 
-  const taxSavingsValues = scenarios.map(s => scenarioResults[s.id]?.taxSavings || 0);
-  const effectiveCostValues = scenarios.map(s => scenarioResults[s.id]?.effectiveCost || 0);
-  const contributionValues = scenarios.map(s => scenarioResults[s.id]?.actualContribution || 0);
+  const summary = scenarios.map((scenario) => {
+    const results = scenarioResults[scenario.id];
+    return {
+      id: scenario.id,
+      name: scenario.name,
+      premiumSavings: results?.annualPremiumSavings ?? 0,
+      employerSeed: results?.employerContribution ?? 0,
+      projectedReserve: results?.projectedReserve ?? 0,
+      reserveGap: results?.reserveShortfall ?? 0,
+      netAdvantage: results?.netCashflowAdvantage ?? 0,
+      employeeContribution: results?.employeeContribution ?? 0,
+    };
+  });
 
-  const bestTaxSavings = getBestValue('taxSavings', taxSavingsValues);
-  const bestEffectiveCost = getBestValue('effectiveCost', effectiveCostValues);
-  const bestContribution = getBestValue('actualContribution', contributionValues);
+  const bestPremium = Math.max(...summary.map((item) => item.premiumSavings));
+  const bestSeed = Math.max(...summary.map((item) => item.employerSeed));
+  const bestReserve = Math.max(...summary.map((item) => item.projectedReserve));
+  const lowestGap = Math.min(...summary.map((item) => item.reserveGap));
+  const bestAdvantage = Math.max(...summary.map((item) => item.netAdvantage));
 
   return (
     <div className="space-y-8">
-      {/* Results Comparison Table */}
       <GlassCard>
-        <h3 className="text-lg font-semibold text-foreground mb-6">Results Comparison</h3>
+        <h3 className="text-lg font-semibold text-foreground mb-6">HDHP Cashflow Comparison</h3>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-border">
                 <th className="text-left p-3 font-medium text-muted-foreground">Metric</th>
-                {scenarios.map(scenario => (
-                  <th key={scenario.id} className="text-center p-3 font-medium text-foreground" data-testid={`header-${scenario.id}`}>
+                {summary.map((scenario) => (
+                  <th key={scenario.id} className="text-center p-3 font-medium text-foreground">
                     {scenario.name}
                   </th>
                 ))}
@@ -121,223 +112,271 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
             </thead>
             <tbody>
               <tr className="border-b border-border">
-                <td className="p-3 font-medium text-foreground">Annual Contribution</td>
-                {scenarios.map(scenario => {
-                  const result = scenarioResults[scenario.id];
-                  const value = result?.actualContribution || 0;
-                  return (
-                    <td key={scenario.id} className="p-3 text-center" data-testid={`contribution-${scenario.id}`}>
-                      <div className="flex items-center justify-center">
-                        <span className="text-lg font-semibold">${value.toLocaleString()}</span>
-                        {getValueIndicator(value, bestContribution, 'actualContribution')}
-                      </div>
-                    </td>
-                  );
-                })}
+                <td className="p-3 font-medium text-foreground">Premium savings vs PPO</td>
+                {summary.map((scenario) => (
+                  <td key={`premium-${scenario.id}`} className="p-3 text-center">
+                    <div className="flex items-center justify-center">
+                      <span className="text-lg font-semibold text-primary">{currency(scenario.premiumSavings)}</span>
+                      {getIndicator(scenario.premiumSavings, bestPremium)}
+                    </div>
+                  </td>
+                ))}
               </tr>
               <tr className="border-b border-border">
-                <td className="p-3 font-medium text-foreground">Tax Savings</td>
-                {scenarios.map(scenario => {
-                  const result = scenarioResults[scenario.id];
-                  const value = result?.taxSavings || 0;
-                  return (
-                    <td key={scenario.id} className="p-3 text-center" data-testid={`tax-savings-${scenario.id}`}>
-                      <div className="flex items-center justify-center">
-                        <span className="text-lg font-semibold text-green-600">${Math.round(value).toLocaleString()}</span>
-                        {getValueIndicator(value, bestTaxSavings, 'taxSavings')}
-                      </div>
-                    </td>
-                  );
-                })}
+                <td className="p-3 font-medium text-foreground">Employer seed money</td>
+                {summary.map((scenario) => (
+                  <td key={`seed-${scenario.id}`} className="p-3 text-center">
+                    <div className="flex items-center justify-center">
+                      <span className="text-lg font-semibold text-emerald-600">{currency(scenario.employerSeed)}</span>
+                      {getIndicator(scenario.employerSeed, bestSeed)}
+                    </div>
+                  </td>
+                ))}
+              </tr>
+              <tr className="border-b border-border">
+                <td className="p-3 font-medium text-foreground">Projected HSA reserve</td>
+                {summary.map((scenario) => (
+                  <td key={`reserve-${scenario.id}`} className="p-3 text-center">
+                    <div className="flex items-center justify-center">
+                      <span className="text-lg font-semibold text-foreground">{currency(scenario.projectedReserve)}</span>
+                      {getIndicator(scenario.projectedReserve, bestReserve)}
+                    </div>
+                  </td>
+                ))}
+              </tr>
+              <tr className="border-b border-border">
+                <td className="p-3 font-medium text-foreground">Deductible gap remaining</td>
+                {summary.map((scenario) => (
+                  <td key={`gap-${scenario.id}`} className="p-3 text-center">
+                    <div className="flex items-center justify-center">
+                      <span className="text-lg font-semibold text-destructive">{currency(scenario.reserveGap)}</span>
+                      {getIndicator(scenario.reserveGap, lowestGap, true)}
+                    </div>
+                  </td>
+                ))}
               </tr>
               <tr>
-                <td className="p-3 font-medium text-foreground">Effective Cost</td>
-                {scenarios.map(scenario => {
-                  const result = scenarioResults[scenario.id];
-                  const value = result?.effectiveCost || 0;
-                  return (
-                    <td key={scenario.id} className="p-3 text-center" data-testid={`effective-cost-${scenario.id}`}>
-                      <div className="flex items-center justify-center">
-                        <span className="text-lg font-semibold text-primary">${Math.round(value).toLocaleString()}</span>
-                        {getValueIndicator(value, bestEffectiveCost, 'effectiveCost')}
-                      </div>
-                    </td>
-                  );
-                })}
+                <td className="p-3 font-medium text-foreground">Net cashflow advantage</td>
+                {summary.map((scenario) => (
+                  <td key={`advantage-${scenario.id}`} className="p-3 text-center">
+                    <div className="flex items-center justify-center">
+                      <span className="text-lg font-semibold text-emerald-600">{currency(scenario.netAdvantage)}</span>
+                      {getIndicator(scenario.netAdvantage, bestAdvantage)}
+                    </div>
+                  </td>
+                ))}
               </tr>
             </tbody>
           </table>
         </div>
       </GlassCard>
 
-      {/* Side-by-Side Parameter Controls */}
       <div className="grid gap-6" style={{ gridTemplateColumns: `repeat(${Math.min(scenarios.length, 3)}, 1fr)` }}>
-        {scenarios.map(scenario => {
+        {scenarios.map((scenario) => {
           const results = scenarioResults[scenario.id];
-          const contributionLimit = results?.contributionLimit || CONTRIBUTION_LIMITS.HSA_INDIVIDUAL;
-          
+          const contributionLimit = getContributionLimit(scenario.data);
+          const coverageLabel = scenario.data.coverage === "family" ? "Family" : "Individual";
+
           return (
-            <GlassCard key={scenario.id} className="space-y-6">
+            <GlassCard key={scenario.id} className="space-y-6" analyticsId={`hsa-scenario-${scenario.id}`}>
               <div className="flex items-start justify-between border-b border-border pb-2">
-                <h4 className="text-lg font-semibold text-foreground" data-testid={`scenario-title-${scenario.id}`}>
-                  {scenario.name}
-                </h4>
+                <div>
+                  <h4 className="text-lg font-semibold text-foreground">{scenario.name}</h4>
+                  <p className="text-xs text-muted-foreground">{coverageLabel} HDHP pairing</p>
+                </div>
                 <Button
                   variant="ghost"
                   size="icon"
                   className="text-muted-foreground hover:text-destructive"
                   onClick={() => onRemoveScenario(scenario.id)}
                   aria-label={`Remove scenario ${scenario.name}`}
-                  data-testid={`button-remove-scenario-${scenario.id}`}
                 >
                   <Trash2 size={16} />
                 </Button>
               </div>
 
-              {/* Account Type */}
-              <div>
-                <Label className="flex items-center text-sm font-medium text-foreground mb-3">
-                  Account Type
-                  <Tooltip content="An HSA can only be used when you are enrolled in a qualified high-deductible health plan (HDHP); your contributions roll over year to year and can be invested. An FSA is sponsored by your employer, gives access to the full annual election immediately, but typically follows a 'use it or lose it' rule unless your employer permits a small carryover or grace period." />
-                </Label>
-                <RadioGroup
-                  value={scenario.data.accountType}
-                  onValueChange={(value) => updateScenarioInput(scenario.id, 'accountType', value as 'hsa' | 'fsa')}
-                  className="grid grid-cols-2 gap-2"
-                >
-                  <div className={`glass-input rounded-lg p-3 cursor-pointer transition-colors text-xs ${
-                    scenario.data.accountType === 'hsa' 
-                      ? 'bg-primary/20 border-primary ring-1 ring-primary/50' 
-                      : 'hover:bg-primary/10'
-                  }`}>
-                    <RadioGroupItem value="hsa" id={`hsa-${scenario.id}`} className="sr-only" />
-                    <Label htmlFor={`hsa-${scenario.id}`} className="cursor-pointer">
-                      <div className="text-center">
-                        <div className="text-primary text-lg mb-1">💗</div>
-                        <div className="font-medium text-foreground text-xs">HSA</div>
-                      </div>
-                    </Label>
+              <div className="grid gap-5">
+                <div className="rounded-xl border border-border/60 p-4 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-sm font-medium text-foreground">Coverage & age</Label>
+                    <Tooltip
+                      title="HDHP compatibility"
+                      content={
+                        <p>
+                          Coverage level and age unlock different IRS limits. Confirm your medical plan is a qualified HDHP
+                          before relying on these HSA numbers.
+                        </p>
+                      }
+                    />
                   </div>
-                  <div className={`glass-input rounded-lg p-3 cursor-pointer transition-colors text-xs ${
-                    scenario.data.accountType === 'fsa' 
-                      ? 'bg-secondary/20 border-secondary ring-1 ring-secondary/50' 
-                      : 'hover:bg-primary/10'
-                  }`}>
-                    <RadioGroupItem value="fsa" id={`fsa-${scenario.id}`} className="sr-only" />
-                    <Label htmlFor={`fsa-${scenario.id}`} className="cursor-pointer">
-                      <div className="text-center">
-                        <div className="text-secondary text-lg mb-1">📋</div>
-                        <div className="font-medium text-foreground text-xs">FSA</div>
-                      </div>
-                    </Label>
-                  </div>
-                </RadioGroup>
-              </div>
+                  <RadioGroup
+                    value={scenario.data.coverage}
+                    onValueChange={(value) => updateScenario(scenario.id, { coverage: value as "individual" | "family" })}
+                    className="grid grid-cols-2 gap-2"
+                  >
+                    <div
+                      className={`glass-input rounded-lg p-3 cursor-pointer transition-colors text-xs ${
+                        scenario.data.coverage === "individual" ? "bg-primary/20 border-primary ring-1 ring-primary/50" : "hover:bg-primary/10"
+                      }`}
+                    >
+                      <RadioGroupItem value="individual" id={`coverage-individual-${scenario.id}`} className="sr-only" />
+                      <Label htmlFor={`coverage-individual-${scenario.id}`} className="cursor-pointer">
+                        <div className="text-center">
+                          <div className="text-primary text-lg mb-1">👤</div>
+                          <div className="font-medium text-foreground text-xs">Individual</div>
+                        </div>
+                      </Label>
+                    </div>
+                    <div
+                      className={`glass-input rounded-lg p-3 cursor-pointer transition-colors text-xs ${
+                        scenario.data.coverage === "family" ? "bg-primary/20 border-primary ring-1 ring-primary/50" : "hover:bg-primary/10"
+                      }`}
+                    >
+                      <RadioGroupItem value="family" id={`coverage-family-${scenario.id}`} className="sr-only" />
+                      <Label htmlFor={`coverage-family-${scenario.id}`} className="cursor-pointer">
+                        <div className="text-center">
+                          <div className="text-primary text-lg mb-1">👨‍👩‍👧‍👦</div>
+                          <div className="font-medium text-foreground text-xs">Family</div>
+                        </div>
+                      </Label>
+                    </div>
+                  </RadioGroup>
 
-              {/* Coverage Level */}
-              <div>
-                <Label className="flex items-center text-sm font-medium text-foreground mb-3">
-                  Coverage
-                  <Tooltip content="Select 'Individual' when your HDHP covers only you. Choose 'Family' if the plan also covers a spouse or dependents; family coverage qualifies for a higher IRS contribution limit because the dollars support multiple people." />
-                </Label>
-                <RadioGroup
-                  value={scenario.data.coverage}
-                  onValueChange={(value) => updateScenarioInput(scenario.id, 'coverage', value as 'individual' | 'family')}
-                  className="grid grid-cols-2 gap-2"
-                >
-                  <div className={`glass-input rounded-lg p-3 cursor-pointer transition-colors text-xs ${
-                    scenario.data.coverage === 'individual' 
-                      ? 'bg-primary/20 border-primary ring-1 ring-primary/50' 
-                      : 'hover:bg-primary/10'
-                  }`}>
-                    <RadioGroupItem value="individual" id={`individual-${scenario.id}`} className="sr-only" />
-                    <Label htmlFor={`individual-${scenario.id}`} className="cursor-pointer">
-                      <div className="text-center">
-                        <div className="text-primary text-sm mb-1">👤</div>
-                        <div className="font-medium text-foreground text-xs">Individual</div>
-                      </div>
-                    </Label>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <Label className="text-xs uppercase text-muted-foreground">Participant age</Label>
+                      <Input
+                        type="number"
+                        min={18}
+                        value={scenario.data.age}
+                        onChange={(event) => updateScenario(scenario.id, { age: Number(event.target.value) || 0 })}
+                      />
+                    </div>
+                    <div className="rounded-lg bg-primary/5 border border-dashed border-primary/40 p-3 text-xs text-muted-foreground">
+                      <p>2025 limit: {currency(contributionLimit)}</p>
+                      <p>Includes {scenario.data.age >= 55 ? "catch-up allowance" : "catch-up once you turn 55"}</p>
+                    </div>
                   </div>
-                  <div className={`glass-input rounded-lg p-3 cursor-pointer transition-colors text-xs ${
-                    scenario.data.coverage === 'family' 
-                      ? 'bg-primary/20 border-primary ring-1 ring-primary/50' 
-                      : 'hover:bg-primary/10'
-                  }`}>
-                    <RadioGroupItem value="family" id={`family-${scenario.id}`} className="sr-only" />
-                    <Label htmlFor={`family-${scenario.id}`} className="cursor-pointer">
-                      <div className="text-center">
-                        <div className="text-primary text-sm mb-1">👨‍👩‍👧‍👦</div>
-                        <div className="font-medium text-foreground text-xs">Family</div>
-                      </div>
-                    </Label>
-                  </div>
-                </RadioGroup>
-              </div>
-
-              {/* Income */}
-              <div>
-                <Label className="text-sm font-medium text-foreground mb-2 block">
-                  Annual Income
-                </Label>
-                <div className="relative">
-                  <span className="absolute left-3 top-3 text-muted-foreground text-sm">$</span>
-                  <Input
-                    type="number"
-                    className="glass-input pl-8"
-                    value={scenario.data.income}
-                    onChange={(e) => updateScenarioInput(scenario.id, 'income', parseFloat(e.target.value) || 0)}
-                    data-testid={`input-income-${scenario.id}`}
-                  />
                 </div>
-              </div>
 
-              {/* Contribution */}
-              <div>
-                <Label className="text-sm font-medium text-foreground mb-2 block">
-                  Annual Contribution: ${(
-                    scenario.data.employeeContribution ?? scenario.data.contribution ?? 0
-                  ).toLocaleString()}
-                </Label>
-                <Slider
-                  value={[scenario.data.employeeContribution ?? scenario.data.contribution ?? 0]}
-                  onValueChange={(value) => {
-                    updateScenarioInput(scenario.id, 'employeeContribution', value[0]);
-                    updateScenarioInput(scenario.id, 'contribution', value[0]);
-                  }}
-                  max={contributionLimit}
-                  min={0}
-                  step={50}
-                  className="w-full"
-                  data-testid={`slider-contribution-${scenario.id}`}
-                />
-                <div className="flex justify-between text-xs text-muted-foreground mt-1">
-                  <span>$0</span>
-                  <span>${contributionLimit.toLocaleString()}</span>
+                <div className="rounded-xl border border-border/60 p-4 space-y-4">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-sm font-medium text-foreground">Premium comparison</Label>
+                    <Tooltip
+                      title="Premium offsets"
+                      content={
+                        <p>
+                          Track how much cheaper the HDHP is each month. Redirect that savings to your HSA so the deductible is
+                          banked before claims arrive.
+                        </p>
+                      }
+                    />
+                  </div>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <Label className="text-xs uppercase text-muted-foreground">HDHP monthly premium</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={scenario.data.hdhpMonthlyPremium}
+                        onChange={(event) => updateScenario(scenario.id, { hdhpMonthlyPremium: Number(event.target.value) || 0 })}
+                      />
+                    </div>
+                    <div>
+                      <Label className="text-xs uppercase text-muted-foreground">Alternative plan premium</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={scenario.data.altPlanMonthlyPremium}
+                        onChange={(event) => updateScenario(scenario.id, { altPlanMonthlyPremium: Number(event.target.value) || 0 })}
+                      />
+                    </div>
+                  </div>
+                  <div className="rounded-lg bg-secondary/10 border border-dashed border-secondary/40 p-3 text-xs text-muted-foreground">
+                    <p>Annual premium savings: {currency(results?.annualPremiumSavings ?? 0)}</p>
+                    <p>Net cashflow advantage: {currency(results?.netCashflowAdvantage ?? 0)}</p>
+                  </div>
                 </div>
-                <div className="mt-1 text-xs text-muted-foreground">
-                  {getLimitText(scenario.data)}
-                </div>
-              </div>
 
-              {/* Tax Bracket */}
-              <div>
-                <Label className="text-sm font-medium text-foreground mb-2 block">
-                  Tax Bracket
-                </Label>
-                <Select value={scenario.data.taxBracket.toString()} onValueChange={(value) => updateScenarioInput(scenario.id, 'taxBracket', parseFloat(value))}>
-                  <SelectTrigger className="glass-input" data-testid={`select-tax-bracket-${scenario.id}`}>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="10">10% - Income up to $11,000</SelectItem>
-                    <SelectItem value="12">12% - Income $11,000 - $44,725</SelectItem>
-                    <SelectItem value="22">22% - Income $44,725 - $95,375</SelectItem>
-                    <SelectItem value="24">24% - Income $95,375 - $182,050</SelectItem>
-                    <SelectItem value="32">32% - Income $182,050 - $231,250</SelectItem>
-                    <SelectItem value="35">35% - Income $231,250 - $578,125</SelectItem>
-                    <SelectItem value="37">37% - Income over $578,125</SelectItem>
-                  </SelectContent>
-                </Select>
+                <div className="rounded-xl border border-border/60 p-4 space-y-4">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-sm font-medium text-foreground">Build the deductible reserve</Label>
+                    <Tooltip
+                      title="Employer contributions"
+                      content={
+                        <p>
+                          Employer seed money can bridge the deductible faster. Combine it with your payroll contributions to
+                          hit the reserve target before high-cost claims appear.
+                        </p>
+                      }
+                    />
+                  </div>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <Label className="text-xs uppercase text-muted-foreground">Employer seed</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={scenario.data.employerSeed}
+                        onChange={(event) => updateScenario(scenario.id, { employerSeed: Number(event.target.value) || 0 })}
+                      />
+                    </div>
+                    <div>
+                      <Label className="text-xs uppercase text-muted-foreground">Target reserve</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={scenario.data.targetReserve}
+                        onChange={(event) => updateScenario(scenario.id, { targetReserve: Number(event.target.value) || 0 })}
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <Label className="text-xs uppercase text-muted-foreground">Employee contribution</Label>
+                    <Slider
+                      value={[scenario.data.employeeContribution]}
+                      onValueChange={(value) => updateScenario(scenario.id, { employeeContribution: value[0] })}
+                      min={0}
+                      max={contributionLimit}
+                      step={50}
+                    />
+                    <div className="flex justify-between text-xs text-muted-foreground mt-1">
+                      <span>$0</span>
+                      <span>{currency(contributionLimit)}</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Payroll dollars planned: {currency(scenario.data.employeeContribution)} • Employer seed: {currency(results?.employerContribution ?? 0)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">Projected reserve: {currency(results?.projectedReserve ?? 0)} • Gap to target: {currency(results?.reserveShortfall ?? 0)}</p>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label className="text-sm font-medium text-foreground">Marginal tax rate</Label>
+                    <Select
+                      value={scenario.data.taxBracket.toString()}
+                      onValueChange={(value) => updateScenario(scenario.id, { taxBracket: parseFloat(value) })}
+                    >
+                      <SelectTrigger className="glass-input">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="10">10% - Income up to $11,000</SelectItem>
+                        <SelectItem value="12">12% - Income $11,000 - $44,725</SelectItem>
+                        <SelectItem value="22">22% - Income $44,725 - $95,375</SelectItem>
+                        <SelectItem value="24">24% - Income $95,375 - $182,050</SelectItem>
+                        <SelectItem value="32">32% - Income $182,050 - $231,250</SelectItem>
+                        <SelectItem value="35">35% - Income $231,250 - $578,125</SelectItem>
+                        <SelectItem value="37">37% - Income over $578,125</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="rounded-xl border border-dashed border-border/60 bg-muted/40 p-4 text-xs text-muted-foreground">
+                    <p>Tax savings: {currency(results?.taxSavings ?? 0)}</p>
+                    <p>Effective cost after taxes: {currency(results?.effectiveCost ?? 0)}</p>
+                  </div>
+                </div>
               </div>
             </GlassCard>
           );

--- a/client/src/components/glass-card.tsx
+++ b/client/src/components/glass-card.tsx
@@ -5,9 +5,10 @@ interface GlassCardProps {
   children: React.ReactNode;
   className?: string;
   onClick?: () => void;
+  analyticsId?: string;
 }
 
-export default function GlassCard({ children, className, onClick }: GlassCardProps) {
+export default function GlassCard({ children, className, onClick, analyticsId }: GlassCardProps) {
   const isInteractive = typeof onClick === "function";
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -33,6 +34,7 @@ export default function GlassCard({ children, className, onClick }: GlassCardPro
       onKeyDown={handleKeyDown}
       role={isInteractive ? "button" : undefined}
       tabIndex={isInteractive ? 0 : undefined}
+      data-analytics-id={analyticsId}
     >
       {children}
     </div>

--- a/client/src/lib/benefitFacts.ts
+++ b/client/src/lib/benefitFacts.ts
@@ -12,9 +12,11 @@ export const BENEFIT_FACTS: Record<CalculatorId, BenefitFact[]> = {
   hsa: [
     { label: "HSA Individual Limit:", value: formatCurrency(CONTRIBUTION_LIMITS.HSA_INDIVIDUAL) },
     { label: "HSA Family Limit:", value: formatCurrency(CONTRIBUTION_LIMITS.HSA_FAMILY) },
+    { label: "Employer seed allowed:", value: "Yes — contributions stack with payroll" },
   ],
   fsa: [
     { label: "Health FSA Limit:", value: formatCurrency(CONTRIBUTION_LIMITS.FSA) },
+    { label: "Use-it-or-lose-it:", value: "Forfeit amounts beyond carryover/grace" },
     { label: "Dependent Care Max:", value: formatCurrency(FSA_LIMITS.dependentCare) },
   ],
   commuter: [

--- a/client/src/lib/pdf/templates/fsa-report.tsx
+++ b/client/src/lib/pdf/templates/fsa-report.tsx
@@ -14,6 +14,13 @@ interface FSAReportProps {
 
 export const FSAReport: React.FC<FSAReportProps> = ({ data }) => {
   const { inputs, results, generatedAt } = data;
+  const talkingPoints = data.additionalData?.narrative as
+    | {
+        electionSizing?: string;
+        gracePeriod?: string;
+        forfeiture?: string;
+      }
+    | undefined;
 
   return (
     <BaseDocument title="FSA Election Analysis" subtitle="Health & Dependent Care FSAs - Tax Year 2025" generatedAt={generatedAt}>
@@ -62,6 +69,22 @@ export const FSAReport: React.FC<FSAReportProps> = ({ data }) => {
           </>
         ) : null}
       </Section>
+
+      <Divider />
+
+      {talkingPoints ? (
+        <Section title="Election Storyline">
+          {talkingPoints.electionSizing && (
+            <Text style={{ fontSize: 9, marginBottom: 6, color: '#374151' }}>{`• ${talkingPoints.electionSizing}`}</Text>
+          )}
+          {talkingPoints.gracePeriod && (
+            <Text style={{ fontSize: 9, marginBottom: 6, color: '#374151' }}>{`• ${talkingPoints.gracePeriod}`}</Text>
+          )}
+          {talkingPoints.forfeiture && (
+            <Text style={{ fontSize: 9, color: '#374151' }}>{`• ${talkingPoints.forfeiture}`}</Text>
+          )}
+        </Section>
+      ) : null}
 
       <Divider />
 

--- a/client/src/lib/pdf/templates/hsa-report.tsx
+++ b/client/src/lib/pdf/templates/hsa-report.tsx
@@ -14,6 +14,14 @@ interface HSAReportProps {
 
 export const HSAReport: React.FC<HSAReportProps> = ({ data }) => {
   const { inputs, results, generatedAt } = data;
+  const talkingPoints = data.additionalData?.narrative as
+    | {
+        compatibility?: string;
+        employerSupport?: string;
+        premiumOffsets?: string;
+        cashflow?: string;
+      }
+    | undefined;
   const coverageText = inputs.coverage === 'family' ? 'Family' : 'Individual';
 
   return (
@@ -73,6 +81,27 @@ export const HSAReport: React.FC<HSAReportProps> = ({ data }) => {
         <ValueRow label="Employer Seed" value={results.employerContribution} currency />
         <ValueRow label="Net Cashflow Advantage" value={results.netCashflowAdvantage} currency highlight />
       </Section>
+
+      {talkingPoints ? (
+        <>
+          <Divider />
+
+          <Section title="HDHP Narrative Highlights">
+            {talkingPoints.compatibility && (
+              <Text style={{ fontSize: 9, marginBottom: 6, color: '#374151' }}>{`• ${talkingPoints.compatibility}`}</Text>
+            )}
+            {talkingPoints.employerSupport && (
+              <Text style={{ fontSize: 9, marginBottom: 6, color: '#374151' }}>{`• ${talkingPoints.employerSupport}`}</Text>
+            )}
+            {talkingPoints.premiumOffsets && (
+              <Text style={{ fontSize: 9, marginBottom: 6, color: '#374151' }}>{`• ${talkingPoints.premiumOffsets}`}</Text>
+            )}
+            {talkingPoints.cashflow && (
+              <Text style={{ fontSize: 9, color: '#374151' }}>{`• ${talkingPoints.cashflow}`}</Text>
+            )}
+          </Section>
+        </>
+      ) : null}
 
       <Divider />
 

--- a/client/src/lib/pdf/use-pdf-export.ts
+++ b/client/src/lib/pdf/use-pdf-export.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { generateAndDownloadPDF, getFilenameSuffix, PDFReportData, ComparisonReportData } from './pdf-utils';
+import { generateAndDownloadPDF, getFilenameSuffix, PDFReportData, ComparisonReportData, formatCurrency } from './pdf-utils';
 import { HSAReport } from './templates/hsa-report';
 import { FSAReport } from './templates/fsa-report';
 import { CommuterReport } from './templates/commuter-report';
@@ -31,12 +31,21 @@ export const usePDFExport = () => {
     setError(null);
     
     try {
+      const coverageText = inputs.coverage === 'family' ? 'family' : 'individual';
       const data: PDFReportData = {
         type: 'hsa',
         title: 'HSA Strategy Analysis',
         generatedAt: new Date(),
         inputs,
-        results
+        results,
+        additionalData: {
+          narrative: {
+            compatibility: `Qualified ${coverageText} HDHP coverage unlocks ${formatCurrency(results.annualContributionLimit)} of annual HSA capacity, including ${formatCurrency(results.catchUpContribution ?? 0)} in catch-up room.`,
+            employerSupport: `Employer contributions of ${formatCurrency(results.employerContribution)} combine with your payroll deferrals to reach the ${formatCurrency(inputs.targetReserve)} reserve target.`,
+            premiumOffsets: `Switching plans frees ${formatCurrency(results.annualPremiumSavings)} in annual premiums that can be redirected to the HSA.`,
+            cashflow: `Net cashflow advantage of ${formatCurrency(results.netCashflowAdvantage)} blends premium savings, employer seeding, and tax benefits to blunt deductible exposure.`
+          }
+        }
       };
       
       const filename = `HSA_Report_${getFilenameSuffix()}.pdf`;
@@ -60,7 +69,14 @@ export const usePDFExport = () => {
         title: 'FSA Election Analysis',
         generatedAt: new Date(),
         inputs,
-        results
+        results,
+        additionalData: {
+          narrative: {
+            electionSizing: `Health FSA election of ${formatCurrency(inputs.healthElection)} captures ${formatCurrency(results.expectedUtilization)} in expected expenses across routine care, planned procedures, and prescriptions.`,
+            gracePeriod: `Carryover allowances protect ${formatCurrency(results.carryoverProtected)} with a ${inputs.gracePeriodMonths.toFixed(1)}-month grace period to finish spending prior-year dollars.`,
+            forfeiture: `Monitor ${formatCurrency(results.forfeitureRisk)} of potential forfeitures and adjust before year-end to preserve the ${formatCurrency(results.netBenefit)} net benefit after taxes.`
+          }
+        }
       };
 
       const filename = `FSA_Report_${getFilenameSuffix()}.pdf`;

--- a/client/src/pages/calculator-hub.tsx
+++ b/client/src/pages/calculator-hub.tsx
@@ -13,20 +13,23 @@ export default function CalculatorHub() {
     description: string;
     icon: typeof HeartPulse;
     route: string;
+    analyticsId: string;
   }> = [
     {
       id: "hsa",
       title: "HSA Strategy Planner",
-      description: "Plan HDHP premium savings, employer seed money, and deductible reserves for your HSA.",
+      description: "Pair your HDHP with employer seeding, premium offsets, and a deductible reserve strategy so the account stays future-ready.",
       icon: HeartPulse,
       route: "/hsa",
+      analyticsId: "calculator-hsa-entry",
     },
     {
       id: "fsa",
       title: "FSA Election Forecaster",
-      description: "Project healthcare and dependent-care expenses to choose confident FSA elections.",
+      description: "Model health and dependent-care elections with carryover rules and avoid forfeiting dollars under use-it-or-lose-it policies.",
       icon: ClipboardList,
       route: "/fsa",
+      analyticsId: "calculator-fsa-entry",
     },
     {
       id: "commuter",
@@ -34,6 +37,7 @@ export default function CalculatorHub() {
       description: "Calculate pre-tax savings on transit and parking expenses for your daily commute.",
       icon: Bus,
       route: "/commuter",
+      analyticsId: "calculator-commuter-entry",
     },
     {
       id: "life",
@@ -41,6 +45,7 @@ export default function CalculatorHub() {
       description: "Determine the right coverage amount using income replacement and debt analysis methodologies.",
       icon: Shield,
       route: "/life-insurance",
+      analyticsId: "calculator-life-entry",
     },
     {
       id: "retirement",
@@ -48,6 +53,7 @@ export default function CalculatorHub() {
       description: "Plan your retirement with compound interest projections and employer matching calculations.",
       icon: TrendingUp,
       route: "/retirement",
+      analyticsId: "calculator-retirement-entry",
     },
   ];
 
@@ -72,6 +78,7 @@ export default function CalculatorHub() {
               key={calculator.id}
               onClick={() => navigate(calculator.route)}
               data-testid={`card-calculator-${calculator.id}`}
+              analyticsId={calculator.analyticsId}
             >
               <div className="text-center">
                 <div className={`w-16 h-16 ${theme.bgClass} rounded-2xl flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform`}>

--- a/client/src/pages/comparison-tool.tsx
+++ b/client/src/pages/comparison-tool.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { ArrowLeft, Plus, GitCompare, HeartPulse, Bus, Shield, TrendingUp, Download } from "lucide-react";
+import { ArrowLeft, Plus, GitCompare, HeartPulse, ClipboardList, Bus, Shield, TrendingUp, Download } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import GlassCard from "@/components/glass-card";
 import HSAComparison from "@/components/comparisons/hsa-comparison";
+import FSAComparison from "@/components/comparisons/fsa-comparison";
 import CommuterComparison from "@/components/comparisons/commuter-comparison";
 import LifeInsuranceComparison from "@/components/comparisons/life-insurance-comparison";
 import RetirementComparison from "@/components/comparisons/retirement-comparison";
@@ -13,7 +14,7 @@ import { useLocation } from "wouter";
 import { usePDFExport } from "@/lib/pdf/use-pdf-export";
 import { CALCULATOR_THEME, type CalculatorId } from "@/lib/calculatorTheme";
 
-type CalculatorType = 'hsa' | 'commuter' | 'life-insurance' | 'retirement';
+type CalculatorType = 'hsa' | 'fsa' | 'commuter' | 'life-insurance' | 'retirement';
 type Scenario = {
   id: string;
   name: string;
@@ -27,6 +28,8 @@ const normaliseCalculatorId = (id: CalculatorType): CalculatorId => {
       return "life";
     case "hsa":
       return "hsa";
+    case "fsa":
+      return "fsa";
     case "commuter":
       return "commuter";
     case "retirement":
@@ -40,6 +43,12 @@ const calculatorTypes = [
     name: 'HSA Strategy',
     icon: HeartPulse,
     description: 'Compare HDHP premium savings and HSA reserve strategies'
+  },
+  {
+    id: 'fsa' as const,
+    name: 'FSA Forecast',
+    icon: ClipboardList,
+    description: 'Compare election sizing, grace periods, and forfeiture exposure'
   },
   {
     id: 'commuter' as const,
@@ -107,6 +116,22 @@ export default function ComparisonTool() {
           employerSeed: 500,
           targetReserve: 4000,
           taxBracket: 22
+        };
+      case 'fsa':
+        return {
+          healthElection: 2600,
+          expectedEligibleExpenses: 2400,
+          planCarryover: 640,
+          gracePeriodMonths: 2,
+          includeDependentCare: true,
+          dependentCareElection: 4000,
+          expectedDependentCareExpenses: 3600,
+          taxBracket: 22,
+          expenseBuckets: {
+            routineCare: 900,
+            plannedProcedures: 1000,
+            pharmacy: 500
+          }
         };
       case 'commuter':
         return {
@@ -195,6 +220,7 @@ export default function ComparisonTool() {
                   onClick={() => setSelectedCalculator(calculator.id)}
                   className="text-center hover:scale-105"
                   data-testid={`card-calculator-${calculator.id}`}
+                  analyticsId={`comparison-select-${calculator.id}`}
                 >
                   <div className={`w-16 h-16 ${theme.bgClass} rounded-2xl flex items-center justify-center mx-auto mb-4`}>
                     <Icon className="text-white" size={32} />
@@ -314,16 +340,24 @@ export default function ComparisonTool() {
               
               {/* Scenario Comparison Components */}
               {selectedCalculator === 'hsa' && (
-                <HSAComparison 
-                  scenarios={scenarios} 
+                <HSAComparison
+                  scenarios={scenarios}
                   onUpdateScenario={handleUpdateScenario}
                   onRemoveScenario={handleRemoveScenario}
                 />
               )}
-              
+
+              {selectedCalculator === 'fsa' && (
+                <FSAComparison
+                  scenarios={scenarios}
+                  onUpdateScenario={handleUpdateScenario}
+                  onRemoveScenario={handleRemoveScenario}
+                />
+              )}
+
               {selectedCalculator === 'commuter' && (
-                <CommuterComparison 
-                  scenarios={scenarios} 
+                <CommuterComparison
+                  scenarios={scenarios}
                   onUpdateScenario={handleUpdateScenario}
                   onRemoveScenario={handleRemoveScenario}
                 />

--- a/client/src/pages/fsa-calculator.tsx
+++ b/client/src/pages/fsa-calculator.tsx
@@ -44,7 +44,7 @@ export default function FSACalculator() {
   };
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-8" data-analytics-id="page-fsa-calculator">
       <div className="flex items-center justify-between mb-8">
         <div className="flex items-center space-x-4">
           <Button

--- a/client/src/pages/hsa-calculator.tsx
+++ b/client/src/pages/hsa-calculator.tsx
@@ -54,7 +54,7 @@ export default function HSACalculator() {
   const reserveProgress = results.projectedReserve;
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-8" data-analytics-id="page-hsa-calculator">
       <div className="flex items-center justify-between mb-8">
         <div className="flex items-center space-x-4">
           <Button


### PR DESCRIPTION
## Summary
- highlight distinct HSA and FSA messaging on the hub cards and add analytics identifiers to interactive glass cards
- introduce an FSA-specific comparison workflow alongside a refocused HSA comparison experience and surface the new calculator selection in the comparison tool
- extend PDF exports to deliver tailored HSA and FSA narratives and update comparison reporting to cover FSA metrics

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d6ab8225ac83209f1a871b165eb669