### PR TITLE
Increase DIME debt and mortgage slider limits to $5M

### DIFF
--- a/client/src/pages/life-insurance-calculator.tsx
+++ b/client/src/pages/life-insurance-calculator.tsx
@@ -78,7 +78,7 @@ export default function LifeInsuranceCalculator() {
                   <Slider
                     value={[inputs.totalDebt]}
                     onValueChange={(value) => updateInput('totalDebt', value[0])}
-                    max={2000000}
+                    max={5000000}
                     min={0}
                     step={5000}
                     className="w-full"
@@ -117,7 +117,7 @@ export default function LifeInsuranceCalculator() {
                   <Slider
                     value={[inputs.mortgageBalance]}
                     onValueChange={(value) => updateInput('mortgageBalance', value[0])}
-                    max={2000000}
+                    max={5000000}
                     min={0}
                     step={5000}
                     className="w-full"

--- a/client/tests/calculations.test.ts
+++ b/client/tests/calculations.test.ts
@@ -68,4 +68,21 @@ describe("calculator math", () => {
     expect(result.additionalNeeded).toBeGreaterThan(0);
   });
 
+  it("handles high debt and mortgage balances up to $5M", () => {
+    const result = calculateLifeInsurance({
+      totalDebt: 5_000_000,
+      income: 120000,
+      mortgageBalance: 5_000_000,
+      educationCosts: 250000,
+      incomeYears: 15,
+      currentInsurance: 500000,
+    });
+
+    const expectedIncomeReplacement = 120000 * 15;
+    const expectedDimeTotal = 5_000_000 + expectedIncomeReplacement + 5_000_000 + 250000;
+
+    expect(result.dimeTotal).toBe(expectedDimeTotal);
+    expect(result.additionalNeeded).toBe(expectedDimeTotal - 500000);
+  });
+
 });


### PR DESCRIPTION
## Summary
- raise the total debt and mortgage balance sliders in the life insurance calculator to allow selections up to $5,000,000
- add a high-value DIME calculation test case to confirm coverage math remains correct at the new limits

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d6bbe6ef50832087e3c5df705c63df