### PR TITLE
Refactor calculators to derive tax rates from income

### DIFF
--- a/client/src/components/comparisons/fsa-comparison.tsx
+++ b/client/src/components/comparisons/fsa-comparison.tsx
@@ -9,9 +9,17 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import GlassCard from "@/components/glass-card";
 import Tooltip from "@/components/tooltip";
 import { calculateFSA, FSA_LIMITS } from "@/lib/calculations";
-import type { FSAInputs, FSAResults } from "@shared/schema";
+import { describeFilingStatus } from "@/lib/tax/brackets";
+import type { FilingStatus, FSAInputs, FSAResults } from "@shared/schema";
 
 const currency = (value: number) => `$${Math.round(value).toLocaleString()}`;
+
+const FILING_STATUS_OPTIONS: { value: FilingStatus; label: string }[] = [
+  { value: "single", label: describeFilingStatus("single") },
+  { value: "marriedJoint", label: describeFilingStatus("marriedJoint") },
+  { value: "marriedSeparate", label: describeFilingStatus("marriedSeparate") },
+  { value: "headOfHousehold", label: describeFilingStatus("headOfHousehold") },
+];
 
 type ExpenseBucketKey = "routineCare" | "plannedProcedures" | "pharmacy";
 
@@ -351,25 +359,37 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                 </div>
 
                 <div className="grid gap-4">
-                  <div>
-                    <Label className="text-sm font-medium text-foreground">Marginal tax rate</Label>
-                    <Select
-                      value={scenario.data.taxBracket.toString()}
-                      onValueChange={(value) => updateScenario(scenario.id, { taxBracket: parseFloat(value) })}
-                    >
-                      <SelectTrigger className="glass-input">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="10">10% - Income up to $11,000</SelectItem>
-                        <SelectItem value="12">12% - Income $11,000 - $44,725</SelectItem>
-                        <SelectItem value="22">22% - Income $44,725 - $95,375</SelectItem>
-                        <SelectItem value="24">24% - Income $95,375 - $182,050</SelectItem>
-                        <SelectItem value="32">32% - Income $182,050 - $231,250</SelectItem>
-                        <SelectItem value="35">35% - Income $231,250 - $578,125</SelectItem>
-                        <SelectItem value="37">37% - Income over $578,125</SelectItem>
-                      </SelectContent>
-                    </Select>
+                  <div className="space-y-3">
+                    <div>
+                      <Label className="text-sm font-medium text-foreground">Household annual income</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={scenario.data.annualIncome}
+                        onChange={(event) => updateScenario(scenario.id, { annualIncome: Number(event.target.value) || 0 })}
+                      />
+                    </div>
+                    <div>
+                      <Label className="text-sm font-medium text-foreground">Filing status</Label>
+                      <Select
+                        value={scenario.data.filingStatus ?? 'single'}
+                        onValueChange={(value: FilingStatus) => updateScenario(scenario.id, { filingStatus: value })}
+                      >
+                        <SelectTrigger className="glass-input">
+                          <SelectValue placeholder="Select filing status" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {FILING_STATUS_OPTIONS.map(option => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Estimated marginal tax rate: <span className="font-semibold text-foreground">{scenarioResults[scenario.id]?.marginalRate ?? 0}%</span>
+                    </p>
                   </div>
 
                   <div className="rounded-xl border border-border/60 p-4 space-y-3">

--- a/client/src/lib/pdf/templates/commuter-report.tsx
+++ b/client/src/lib/pdf/templates/commuter-report.tsx
@@ -58,7 +58,8 @@ export const CommuterReport: React.FC<CommuterReportProps> = ({ data }) => {
         <ValueRow label="Monthly Transit Costs" value={inputs.transitCost} currency />
         <ValueRow label="Monthly Parking Costs" value={inputs.parkingCost} currency />
         <ValueRow label="Total Monthly Commute" value={inputs.transitCost + inputs.parkingCost} currency highlight />
-        <ValueRow label="Tax Bracket" value={`${inputs.taxBracket}%`} />
+        <ValueRow label="Household Annual Income" value={inputs.annualIncome} currency />
+        <ValueRow label="Marginal Tax Rate" value={`${results.marginalRate}%`} />
       </Section>
 
       <Divider />
@@ -82,11 +83,11 @@ export const CommuterReport: React.FC<CommuterReportProps> = ({ data }) => {
             primary 
           />
           <ValueRow label="Annual Transit Benefit" value={results.annualTransit} currency />
-          <ValueRow 
-            label="Annual Tax Savings ({inputs.taxBracket}%)" 
-            value={results.transitSavings} 
-            currency 
-            success 
+          <ValueRow
+            label={`Annual Tax Savings (${results.marginalRate}%)`}
+            value={results.transitSavings}
+            currency
+            success
           />
         </View>
 
@@ -103,11 +104,11 @@ export const CommuterReport: React.FC<CommuterReportProps> = ({ data }) => {
             primary 
           />
           <ValueRow label="Annual Parking Benefit" value={results.annualParking} currency />
-          <ValueRow 
-            label="Annual Tax Savings ({inputs.taxBracket}%)" 
-            value={results.parkingSavings} 
-            currency 
-            success 
+          <ValueRow
+            label={`Annual Tax Savings (${results.marginalRate}%)`}
+            value={results.parkingSavings}
+            currency
+            success
           />
         </View>
 
@@ -200,7 +201,7 @@ export const CommuterReport: React.FC<CommuterReportProps> = ({ data }) => {
         {inputs.parkingCost > 315 && (
           <Text style={{ fontSize: 9, marginBottom: 5, color: '#374151' }}>
             • Your parking costs ({formatCurrency(inputs.parkingCost)}) exceed the monthly limit. 
-            You'll save the maximum {formatCurrency((315 * (inputs.taxBracket / 100)) * 12)} annually on parking.
+            You'll save the maximum {formatCurrency((315 * (results.marginalRate / 100)) * 12)} annually on parking.
           </Text>
         )}
         

--- a/client/src/lib/pdf/templates/comparison-report.tsx
+++ b/client/src/lib/pdf/templates/comparison-report.tsx
@@ -72,6 +72,8 @@ export const ComparisonReport: React.FC<ComparisonReportProps> = ({ data }) => {
                 </Text>
                 <ValueRow label="Account Type" value={(scenario.inputs.accountType ?? 'hsa').toUpperCase()} />
                 <ValueRow label="Coverage" value={scenario.inputs.coverage === 'family' ? 'Family' : 'Individual'} />
+                <ValueRow label="Household Annual Income" value={scenario.inputs.annualIncome} currency />
+                <ValueRow label="Marginal Tax Rate" value={`${hsaResults.marginalRate}%`} />
                 <ValueRow label="Annual Contribution" value={hsaResults.totalContribution ?? hsaResults.actualContribution ?? 0} currency />
                 <ValueRow label="Tax Savings" value={hsaResults.taxSavings} currency success />
                 <ValueRow label="Effective Cost" value={hsaResults.effectiveCost ?? 0} currency primary />
@@ -100,6 +102,8 @@ export const ComparisonReport: React.FC<ComparisonReportProps> = ({ data }) => {
                 <ValueRow label="Health FSA Election" value={scenario.inputs.healthElection} currency />
                 <ValueRow label="Expected Utilisation" value={fsaResults.expectedUtilization} currency primary />
                 <ValueRow label="Carryover Protected" value={fsaResults.carryoverProtected} currency />
+                <ValueRow label="Household Annual Income" value={scenario.inputs.annualIncome} currency />
+                <ValueRow label="Marginal Tax Rate" value={`${fsaResults.marginalRate}%`} />
                 <ValueRow label="Grace Period Months" value={(scenario.inputs.gracePeriodMonths ?? 0).toFixed(1)} />
                 <ValueRow label="Forfeiture Risk" value={fsaResults.forfeitureRisk} currency highlight />
                 <ValueRow label="Net Benefit" value={fsaResults.netBenefit} currency success />
@@ -134,6 +138,8 @@ export const ComparisonReport: React.FC<ComparisonReportProps> = ({ data }) => {
                 </Text>
                 <ValueRow label="Monthly Transit Cost" value={scenario.inputs.transitCost} currency />
                 <ValueRow label="Monthly Parking Cost" value={scenario.inputs.parkingCost} currency />
+                <ValueRow label="Household Annual Income" value={scenario.inputs.annualIncome} currency />
+                <ValueRow label="Marginal Tax Rate" value={`${commuterResults.marginalRate}%`} />
                 <ValueRow label="Transit Savings" value={commuterResults.transitSavings} currency />
                 <ValueRow label="Parking Savings" value={commuterResults.parkingSavings} currency />
                 <ValueRow label="Total Annual Savings" value={commuterResults.totalSavings} currency success />

--- a/client/src/lib/pdf/templates/fsa-report.tsx
+++ b/client/src/lib/pdf/templates/fsa-report.tsx
@@ -60,7 +60,8 @@ export const FSAReport: React.FC<FSAReportProps> = ({ data }) => {
         <ValueRow label="Expected Eligible Expenses" value={inputs.expectedEligibleExpenses} currency />
         <ValueRow label="Carryover Allowance" value={inputs.planCarryover} currency />
         <ValueRow label="Grace Period" value={`${inputs.gracePeriodMonths.toFixed(1)} months`} />
-        <ValueRow label="Marginal Tax Rate" value={`${inputs.taxBracket}%`} />
+        <ValueRow label="Household Annual Income" value={inputs.annualIncome} currency />
+        <ValueRow label="Marginal Tax Rate" value={`${results.marginalRate}%`} />
         <ValueRow label="Dependent-care Included" value={inputs.includeDependentCare ? 'Yes' : 'No'} />
         {inputs.includeDependentCare ? (
           <>

--- a/client/src/lib/pdf/templates/hsa-report.tsx
+++ b/client/src/lib/pdf/templates/hsa-report.tsx
@@ -60,7 +60,8 @@ export const HSAReport: React.FC<HSAReportProps> = ({ data }) => {
       <Section title="HDHP & Contribution Details">
         <ValueRow label="Coverage Level" value={coverageText} />
         <ValueRow label="Participant Age" value={inputs.age} />
-        <ValueRow label="Marginal Tax Rate" value={`${inputs.taxBracket}%`} />
+        <ValueRow label="Household Annual Income" value={inputs.annualIncome} currency />
+        <ValueRow label="Marginal Tax Rate" value={`${results.marginalRate}%`} />
         <ValueRow label="2025 Contribution Limit" value={results.annualContributionLimit} currency highlight />
         <ValueRow label="Employee Contribution" value={results.employeeContribution} currency />
         <ValueRow label="Employer Contribution" value={results.employerContribution} currency />

--- a/client/src/lib/tax/brackets.ts
+++ b/client/src/lib/tax/brackets.ts
@@ -1,0 +1,81 @@
+import type { FilingStatus } from "@shared/schema";
+
+export interface TaxBracketThreshold {
+  upTo: number | null;
+  rate: number;
+}
+
+export const TAX_BRACKETS_2025: Record<FilingStatus, TaxBracketThreshold[]> = {
+  single: [
+    { upTo: 11_600, rate: 10 },
+    { upTo: 47_150, rate: 12 },
+    { upTo: 100_525, rate: 22 },
+    { upTo: 191_950, rate: 24 },
+    { upTo: 243_725, rate: 32 },
+    { upTo: 609_350, rate: 35 },
+    { upTo: null, rate: 37 },
+  ],
+  marriedJoint: [
+    { upTo: 23_200, rate: 10 },
+    { upTo: 94_300, rate: 12 },
+    { upTo: 201_050, rate: 22 },
+    { upTo: 383_900, rate: 24 },
+    { upTo: 487_450, rate: 32 },
+    { upTo: 731_200, rate: 35 },
+    { upTo: null, rate: 37 },
+  ],
+  marriedSeparate: [
+    { upTo: 11_600, rate: 10 },
+    { upTo: 47_150, rate: 12 },
+    { upTo: 100_525, rate: 22 },
+    { upTo: 191_950, rate: 24 },
+    { upTo: 243_725, rate: 32 },
+    { upTo: 365_600, rate: 35 },
+    { upTo: null, rate: 37 },
+  ],
+  headOfHousehold: [
+    { upTo: 16_550, rate: 10 },
+    { upTo: 63_100, rate: 12 },
+    { upTo: 100_500, rate: 22 },
+    { upTo: 191_950, rate: 24 },
+    { upTo: 243_700, rate: 32 },
+    { upTo: 609_350, rate: 35 },
+    { upTo: null, rate: 37 },
+  ],
+};
+
+export function getMarginalTaxRate(
+  annualIncome: number | undefined,
+  filingStatus: FilingStatus | undefined
+): number {
+  if (!Number.isFinite(annualIncome ?? NaN) || (annualIncome ?? 0) <= 0) {
+    return 0;
+  }
+
+  const status: FilingStatus = filingStatus ?? 'single';
+  const income = Math.max(annualIncome ?? 0, 0);
+  const brackets = TAX_BRACKETS_2025[status];
+
+  for (const bracket of brackets) {
+    if (bracket.upTo === null || income <= bracket.upTo) {
+      return bracket.rate;
+    }
+  }
+
+  return brackets[brackets.length - 1]?.rate ?? 0;
+}
+
+export function describeFilingStatus(status: FilingStatus): string {
+  switch (status) {
+    case 'single':
+      return 'Single';
+    case 'marriedJoint':
+      return 'Married filing jointly';
+    case 'marriedSeparate':
+      return 'Married filing separately';
+    case 'headOfHousehold':
+      return 'Head of household';
+    default:
+      return status;
+  }
+}

--- a/client/src/pages/comparison-tool.tsx
+++ b/client/src/pages/comparison-tool.tsx
@@ -106,7 +106,8 @@ export default function ComparisonTool() {
           altPlanMonthlyPremium: 520,
           employerSeed: 500,
           targetReserve: 4000,
-          taxBracket: 22
+          annualIncome: 95000,
+          filingStatus: 'single'
         };
       case 'fsa':
         return {
@@ -117,7 +118,8 @@ export default function ComparisonTool() {
           includeDependentCare: true,
           dependentCareElection: 4000,
           expectedDependentCareExpenses: 3600,
-          taxBracket: 22,
+          annualIncome: 95000,
+          filingStatus: 'single',
           expenseBuckets: {
             routineCare: 900,
             plannedProcedures: 1000,
@@ -128,7 +130,8 @@ export default function ComparisonTool() {
         return {
           transitCost: 200,
           parkingCost: 150,
-          taxBracket: 22
+          annualIncome: 95000,
+          filingStatus: 'single'
         };
       case 'life-insurance':
         return {

--- a/client/src/pages/fsa-calculator.tsx
+++ b/client/src/pages/fsa-calculator.tsx
@@ -5,12 +5,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import GlassCard from "@/components/glass-card";
 import Tooltip from "@/components/tooltip";
 import DecisionSlider from "@/components/calculators/decision-slider";
 import ShowMathSection from "@/components/calculators/show-math";
 import { calculateFSA, FSA_LIMITS } from "@/lib/calculations";
-import { FSAInputs, FSAResults } from "@shared/schema";
+import { getMarginalTaxRate, describeFilingStatus } from "@/lib/tax/brackets";
+import { FSAInputs, FSAResults, FilingStatus } from "@shared/schema";
 import { usePDFExport } from "@/lib/pdf/use-pdf-export";
 
 const DEFAULT_INPUTS: FSAInputs = {
@@ -21,8 +23,16 @@ const DEFAULT_INPUTS: FSAInputs = {
   includeDependentCare: true,
   dependentCareElection: 4000,
   expectedDependentCareExpenses: 3600,
-  taxBracket: 22,
+  annualIncome: 85000,
+  filingStatus: "single",
 };
+
+const FILING_STATUS_OPTIONS: { value: FilingStatus; label: string }[] = [
+  { value: "single", label: describeFilingStatus("single") },
+  { value: "marriedJoint", label: describeFilingStatus("marriedJoint") },
+  { value: "marriedSeparate", label: describeFilingStatus("marriedSeparate") },
+  { value: "headOfHousehold", label: describeFilingStatus("headOfHousehold") },
+];
 
 const currency = (value: number) => `$${Math.round(value).toLocaleString()}`;
 
@@ -38,6 +48,7 @@ export default function FSACalculator() {
   }, [inputs]);
 
   const carryoverCeiling = useMemo(() => Math.min(inputs.planCarryover, inputs.healthElection), [inputs.planCarryover, inputs.healthElection]);
+  const marginalRate = results.marginalRate ?? getMarginalTaxRate(inputs.annualIncome, inputs.filingStatus);
 
   const updateInput = <K extends keyof FSAInputs>(key: K, value: FSAInputs[K]) => {
     setInputs(prev => ({ ...prev, [key]: value }));
@@ -127,18 +138,40 @@ export default function FSACalculator() {
 
               <div className="space-y-4">
                 <div>
-                  <Label htmlFor="tax-rate" className="text-sm font-medium text-foreground mb-2">
-                    Marginal tax rate (%)
+                  <Label htmlFor="annual-income" className="text-sm font-medium text-foreground mb-2">
+                    Household annual income
                   </Label>
                   <Input
-                    id="tax-rate"
+                    id="annual-income"
                     type="number"
                     min={0}
-                    max={50}
-                    value={inputs.taxBracket}
-                    onChange={(event) => updateInput("taxBracket", Number(event.target.value) || 0)}
+                    value={inputs.annualIncome}
+                    onChange={(event) => updateInput("annualIncome", Number(event.target.value) || 0)}
                   />
                 </div>
+
+                <div>
+                  <Label className="text-sm font-medium text-foreground mb-2">Filing status</Label>
+                  <Select
+                    value={inputs.filingStatus ?? "single"}
+                    onValueChange={(value: FilingStatus) => updateInput("filingStatus", value)}
+                  >
+                    <SelectTrigger className="glass-input">
+                      <SelectValue placeholder="Select filing status" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {FILING_STATUS_OPTIONS.map(option => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <p className="text-xs text-muted-foreground">
+                  Estimated marginal tax rate: <span className="font-semibold text-foreground">{marginalRate}%</span>
+                </p>
 
                 <div>
                   <Label className="text-sm font-medium text-foreground mb-2">Carryover or grace period</Label>

--- a/client/tests/calculations.test.ts
+++ b/client/tests/calculations.test.ts
@@ -19,20 +19,25 @@ describe("calculator math", () => {
       hdhpMonthlyPremium: 300,
       altPlanMonthlyPremium: 500,
       targetReserve: 6000,
-      taxBracket: 24,
+      annualIncome: 185000,
+      filingStatus: "marriedJoint",
     });
 
     expect(result.annualContributionLimit).toBe(HSA_LIMITS.family + HSA_LIMITS.catchUp);
     expect(result.totalContribution).toBe(result.annualContributionLimit);
     expect(result.catchUpContribution).toBe(HSA_LIMITS.catchUp);
-    expect(result.taxSavings).toBeCloseTo(result.employeeContribution * 0.24, 2);
+    expect(result.marginalRate).toBeGreaterThan(0);
+    expect(result.taxSavings).toBeCloseTo(result.employeeContribution * (result.marginalRate / 100), 2);
     expect(result.annualPremiumSavings).toBeCloseTo((500 - 300) * 12);
   });
 
   it("caps commuter transit at $315/mo", () => {
-    const result = calculateCommuter({ transitCost: 500, parkingCost: 250, taxBracket: 22 });
+    const result = calculateCommuter({ transitCost: 500, parkingCost: 250, annualIncome: 90000, filingStatus: "single" });
     expect(result.annualTransit).toBe(COMMUTER_LIMITS.transit * 12);
-    expect(result.totalSavings).toBeCloseTo(result.annualTransit * 0.22 + result.annualParking * 0.22, 2);
+    expect(result.totalSavings).toBeCloseTo(
+      result.annualTransit * (result.marginalRate / 100) + result.annualParking * (result.marginalRate / 100),
+      2
+    );
   });
 
   it("estimates FSA forfeiture risk with carryover and grace period protections", () => {
@@ -44,13 +49,15 @@ describe("calculator math", () => {
       includeDependentCare: true,
       dependentCareElection: 6000,
       expectedDependentCareExpenses: 4000,
-      taxBracket: 24,
+      annualIncome: 165000,
+      filingStatus: "marriedJoint",
     });
 
     expect(result.cappedHealthElection).toBe(FSA_LIMITS.health);
     expect(result.forfeitureRisk).toBeGreaterThanOrEqual(0);
-    expect(result.taxSavings).toBeCloseTo(FSA_LIMITS.health * 0.24, 2);
-    expect(result.dependentCareTaxSavings).toBeCloseTo(FSA_LIMITS.dependentCare * 0.24, 2);
+    expect(result.marginalRate).toBeGreaterThan(0);
+    expect(result.taxSavings).toBeCloseTo(FSA_LIMITS.health * (result.marginalRate / 100), 2);
+    expect(result.dependentCareTaxSavings).toBeCloseTo(FSA_LIMITS.dependentCare * (result.marginalRate / 100), 2);
     expect(result.dependentCareForfeitureRisk).toBeCloseTo(FSA_LIMITS.dependentCare - 4000, 2);
   });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -20,6 +20,8 @@ export type InsertCalculationSession = z.infer<typeof insertCalculationSessionSc
 export type CalculationSession = typeof calculationSessions.$inferSelect;
 
 // Type definitions for calculator inputs and results
+export type FilingStatus = 'single' | 'marriedJoint' | 'marriedSeparate' | 'headOfHousehold';
+
 export interface HSAInputs {
   coverage: 'individual' | 'family';
   age: number;
@@ -28,11 +30,14 @@ export interface HSAInputs {
   altPlanMonthlyPremium: number;
   employerSeed: number;
   targetReserve: number;
-  taxBracket: number;
+  annualIncome: number;
+  filingStatus?: FilingStatus;
   // Legacy fields supported for backward compatibility with existing UI state
   accountType?: 'hsa' | 'fsa';
   income?: number;
   contribution?: number;
+  /** @deprecated */
+  taxBracket?: number;
 }
 
 export interface HSAResults {
@@ -46,6 +51,7 @@ export interface HSAResults {
   netCashflowAdvantage: number;
   projectedReserve: number;
   reserveShortfall: number;
+  marginalRate: number;
   // Legacy fields still consumed by the UI and reports
   actualContribution?: number;
   contributionLimit?: number;
@@ -61,7 +67,10 @@ export interface FSAInputs {
   includeDependentCare: boolean;
   dependentCareElection: number;
   expectedDependentCareExpenses: number;
-  taxBracket: number;
+  annualIncome: number;
+  filingStatus?: FilingStatus;
+  /** @deprecated */
+  taxBracket?: number;
 }
 
 export interface FSAResults {
@@ -73,12 +82,16 @@ export interface FSAResults {
   netBenefit: number;
   dependentCareTaxSavings: number;
   dependentCareForfeitureRisk: number;
+  marginalRate: number;
 }
 
 export interface CommuterInputs {
   transitCost: number;
   parkingCost: number;
-  taxBracket: number;
+  annualIncome: number;
+  filingStatus?: FilingStatus;
+  /** @deprecated */
+  taxBracket?: number;
 }
 
 export interface CommuterResults {
@@ -88,6 +101,7 @@ export interface CommuterResults {
   annualTransit: number;
   annualParking: number;
   annualTotal: number;
+  marginalRate: number;
 }
 
 export interface LifeInsuranceInputs {


### PR DESCRIPTION
## Summary
- add a 2025 marginal tax bracket helper and expose the filing status type
- update HSA, FSA, and commuter calculators plus comparison tools to collect annual income and filing status and show derived marginal rates
- refactor shared calculation logic, tests, and PDF/report templates to use income-derived tax rates and persist both income and calculated rates

## Testing
- npm run test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d6bc8d78788320b140abe15af85038