### PR TITLE
Clarify HSA copy across calculator and PDF

### DIFF
--- a/client/src/components/comparisons/hsa-comparison.tsx
+++ b/client/src/components/comparisons/hsa-comparison.tsx
@@ -76,7 +76,9 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
       <GlassCard>
         <div className="text-center py-8">
           <Calculator className="mx-auto text-muted-foreground mb-4" size={48} />
-          <p className="text-muted-foreground">Add HSA scenarios above to analyse premium savings and deductible exposure.</p>
+          <p className="text-muted-foreground">
+            Add HSA scenarios above to compare plan costs, HSA deposits, and savings in everyday language.
+          </p>
         </div>
       </GlassCard>
     );
@@ -105,12 +107,12 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
   return (
     <div className="space-y-8">
       <GlassCard>
-        <h3 className="text-lg font-semibold text-foreground mb-6">HDHP Cashflow Comparison</h3>
+        <h3 className="text-lg font-semibold text-foreground mb-6">Compare plan savings and HSA funding</h3>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-border">
-                <th className="text-left p-3 font-medium text-muted-foreground">Metric</th>
+                <th className="text-left p-3 font-medium text-muted-foreground">What we are measuring</th>
                 {summary.map((scenario) => (
                   <th key={scenario.id} className="text-center p-3 font-medium text-foreground">
                     {scenario.name}
@@ -120,7 +122,7 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
             </thead>
             <tbody>
               <tr className="border-b border-border">
-                <td className="p-3 font-medium text-foreground">Premium savings vs PPO</td>
+                <td className="p-3 font-medium text-foreground">Yearly premium savings versus the other plan</td>
                 {summary.map((scenario) => (
                   <td key={`premium-${scenario.id}`} className="p-3 text-center">
                     <div className="flex items-center justify-center">
@@ -131,7 +133,7 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                 ))}
               </tr>
               <tr className="border-b border-border">
-                <td className="p-3 font-medium text-foreground">Employer seed money</td>
+                <td className="p-3 font-medium text-foreground">Employer HSA contribution</td>
                 {summary.map((scenario) => (
                   <td key={`seed-${scenario.id}`} className="p-3 text-center">
                     <div className="flex items-center justify-center">
@@ -142,7 +144,7 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                 ))}
               </tr>
               <tr className="border-b border-border">
-                <td className="p-3 font-medium text-foreground">Projected HSA reserve</td>
+                <td className="p-3 font-medium text-foreground">Estimated HSA balance after contributions</td>
                 {summary.map((scenario) => (
                   <td key={`reserve-${scenario.id}`} className="p-3 text-center">
                     <div className="flex items-center justify-center">
@@ -153,7 +155,7 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                 ))}
               </tr>
               <tr className="border-b border-border">
-                <td className="p-3 font-medium text-foreground">Deductible gap remaining</td>
+                <td className="p-3 font-medium text-foreground">Estimated shortfall to your reserve goal</td>
                 {summary.map((scenario) => (
                   <td key={`gap-${scenario.id}`} className="p-3 text-center">
                     <div className="flex items-center justify-center">
@@ -164,7 +166,7 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                 ))}
               </tr>
               <tr>
-                <td className="p-3 font-medium text-foreground">Net cashflow advantage</td>
+                <td className="p-3 font-medium text-foreground">Money left after savings and deposits</td>
                 {summary.map((scenario) => (
                   <td key={`advantage-${scenario.id}`} className="p-3 text-center">
                     <div className="flex items-center justify-center">
@@ -190,7 +192,7 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
               <div className="flex items-start justify-between border-b border-border pb-2">
                 <div>
                   <h4 className="text-lg font-semibold text-foreground">{scenario.name}</h4>
-                  <p className="text-xs text-muted-foreground">{coverageLabel} HDHP pairing</p>
+                  <p className="text-xs text-muted-foreground">{coverageLabel} HDHP scenario overview</p>
                 </div>
                 <Button
                   variant="ghost"
@@ -211,8 +213,8 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                       title="HDHP compatibility"
                       content={
                         <p>
-                          Coverage level and age unlock different IRS limits. Confirm your medical plan is a qualified HDHP
-                          before relying on these HSA numbers.
+                          Your coverage level and age decide how much the IRS lets you put in an HSA. Confirm the medical plan
+                          counts as an HDHP before relying on these results.
                         </p>
                       }
                     />
@@ -262,7 +264,7 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                     </div>
                     <div className="rounded-lg bg-primary/5 border border-dashed border-primary/40 p-3 text-xs text-muted-foreground">
                       <p>2025 limit: {currency(contributionLimit)}</p>
-                      <p>Includes {scenario.data.age >= 55 ? "catch-up allowance" : "catch-up once you turn 55"}</p>
+                      <p>{scenario.data.age >= 55 ? "Includes the $1,000 catch-up for age 55+" : "Add $1,000 more once you turn 55"}</p>
                     </div>
                   </div>
                 </div>
@@ -275,7 +277,7 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                       content={
                         <p>
                           Track how much cheaper the HDHP is each month. Redirect that savings to your HSA so the deductible is
-                          banked before claims arrive.
+                          covered before any claims arrive.
                         </p>
                       }
                     />
@@ -302,7 +304,7 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                   </div>
                   <div className="rounded-lg bg-secondary/10 border border-dashed border-secondary/40 p-3 text-xs text-muted-foreground">
                     <p>Annual premium savings: {currency(results?.annualPremiumSavings ?? 0)}</p>
-                    <p>Net cashflow advantage: {currency(results?.netCashflowAdvantage ?? 0)}</p>
+                    <p>Money left after inflows and deposits: {currency(results?.netCashflowAdvantage ?? 0)}</p>
                   </div>
                 </div>
 
@@ -313,15 +315,15 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                       title="Employer contributions"
                       content={
                         <p>
-                          Employer seed money can bridge the deductible faster. Combine it with your payroll contributions to
-                          hit the reserve target before high-cost claims appear.
+                          Employer contributions can bridge the deductible faster. Combine them with your payroll deposits to
+                          reach the reserve target before high-cost claims appear.
                         </p>
                       }
                     />
                   </div>
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <Label className="text-xs uppercase text-muted-foreground">Employer seed</Label>
+                      <Label className="text-xs uppercase text-muted-foreground">Employer contribution</Label>
                       <Input
                         type="number"
                         min={0}
@@ -353,9 +355,15 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                       <span>{currency(contributionLimit)}</span>
                     </div>
                     <p className="text-xs text-muted-foreground mt-1">
-                      Payroll dollars planned: {currency(scenario.data.employeeContribution)} • Employer seed: {currency(results?.employerContribution ?? 0)}
+                      Payroll contributions planned: {currency(scenario.data.employeeContribution)} • Employer contribution:
+                      {" "}
+                      {currency(results?.employerContribution ?? 0)}
                     </p>
-                    <p className="text-xs text-muted-foreground">Projected reserve: {currency(results?.projectedReserve ?? 0)} • Gap to target: {currency(results?.reserveShortfall ?? 0)}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Projected HSA balance: {currency(results?.projectedReserve ?? 0)} • Difference from your goal:
+                      {" "}
+                      {currency(results?.reserveShortfall ?? 0)}
+                    </p>
                   </div>
                 </div>
 
@@ -394,7 +402,7 @@ export default function HSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                   </div>
                   <div className="rounded-xl border border-dashed border-border/60 bg-muted/40 p-4 text-xs text-muted-foreground">
                     <p>Tax savings: {currency(results?.taxSavings ?? 0)}</p>
-                    <p>Effective cost after taxes: {currency(results?.effectiveCost ?? 0)}</p>
+                    <p>Estimated after-tax cost of the HDHP: {currency(results?.effectiveCost ?? 0)}</p>
                   </div>
                 </div>
               </div>

--- a/client/src/lib/benefitFacts.ts
+++ b/client/src/lib/benefitFacts.ts
@@ -10,9 +10,18 @@ const formatCurrency = (amount: number) => `$${amount.toLocaleString()}`;
 
 export const BENEFIT_FACTS: Record<CalculatorId, BenefitFact[]> = {
   hsa: [
-    { label: "HSA Individual Limit:", value: formatCurrency(CONTRIBUTION_LIMITS.HSA_INDIVIDUAL) },
-    { label: "HSA Family Limit:", value: formatCurrency(CONTRIBUTION_LIMITS.HSA_FAMILY) },
-    { label: "Employer seed allowed:", value: "Yes — contributions stack with payroll" },
+    {
+      label: "Individual contribution limit (2025):",
+      value: `${formatCurrency(CONTRIBUTION_LIMITS.HSA_INDIVIDUAL)} plus an extra $1,000 once you turn 55`,
+    },
+    {
+      label: "Family contribution limit (2025):",
+      value: `${formatCurrency(CONTRIBUTION_LIMITS.HSA_FAMILY)} plus the $1,000 age-55 catch-up allowance`,
+    },
+    {
+      label: "Employer contributions:",
+      value: "Allowed on top of your deposits—confirm whether the money arrives upfront or through matching",
+    },
   ],
   fsa: [
     { label: "Health FSA Limit:", value: formatCurrency(CONTRIBUTION_LIMITS.FSA) },

--- a/client/src/lib/pdf/templates/hsa-report.tsx
+++ b/client/src/lib/pdf/templates/hsa-report.tsx
@@ -32,32 +32,32 @@ export const HSAReport: React.FC<HSAReportProps> = ({ data }) => {
             title="Annual Premium Savings"
             value={results.annualPremiumSavings}
             currency
-            description="Budget freed by choosing the HDHP"
+            description="Money saved on premiums by choosing the HDHP"
           />
           <MetricCard
             title="Tax Savings"
             value={results.taxSavings}
             currency
-            description="Pre-tax payroll reduction"
+            description="Taxes avoided because HSA deposits come out before tax"
           />
           <MetricCard
             title="Total HSA Funding"
             value={results.totalContribution}
             currency
-            description="Employee and employer dollars combined"
+            description="Total HSA deposits from you and your employer"
           />
           <MetricCard
             title="Net Cashflow Advantage"
             value={results.netCashflowAdvantage}
             currency
-            description="Premium gap + seed + tax savings − payroll"
+            description="Premium savings plus employer contributions and tax savings minus your deposits"
           />
         </MetricGrid>
       </Section>
 
       <Divider />
 
-      <Section title="HDHP & Contribution Details">
+      <Section title="Plan and contribution details">
         <ValueRow label="Coverage Level" value={coverageText} />
         <ValueRow label="Participant Age" value={inputs.age} />
         <ValueRow label="Household Annual Income" value={inputs.annualIncome} currency />
@@ -70,16 +70,16 @@ export const HSAReport: React.FC<HSAReportProps> = ({ data }) => {
 
       <Divider />
 
-      <Section title="Premium Comparison & Cashflow">
+      <Section title="Premium comparison and cash flow">
         <Text style={{ fontSize: 10, marginBottom: 10, color: '#374151' }}>
-          HDHPs swap predictable copays for lower premiums. Redirect the premium gap and tax savings into the HSA so the
-          deductible is covered when claims arrive.
+          A high-deductible health plan (HDHP) trades copays for lower premiums. Redirect the premium difference and tax
+          savings into the health savings account (HSA) so the deductible is ready when medical bills show up.
         </Text>
         <ValueRow label="HDHP Monthly Premium" value={inputs.hdhpMonthlyPremium} currency />
         <ValueRow label="Alternative Plan Premium" value={inputs.altPlanMonthlyPremium} currency />
         <ValueRow label="Annual Premium Savings" value={results.annualPremiumSavings} currency primary />
         <ValueRow label="Tax Savings" value={results.taxSavings} currency />
-        <ValueRow label="Employer Seed" value={results.employerContribution} currency />
+        <ValueRow label="Employer Contribution" value={results.employerContribution} currency />
         <ValueRow label="Net Cashflow Advantage" value={results.netCashflowAdvantage} currency highlight />
       </Section>
 
@@ -87,7 +87,7 @@ export const HSAReport: React.FC<HSAReportProps> = ({ data }) => {
         <>
           <Divider />
 
-          <Section title="HDHP Narrative Highlights">
+          <Section title="Plain-language highlights">
             {talkingPoints.compatibility && (
               <Text style={{ fontSize: 9, marginBottom: 6, color: '#374151' }}>{`• ${talkingPoints.compatibility}`}</Text>
             )}
@@ -112,7 +112,7 @@ export const HSAReport: React.FC<HSAReportProps> = ({ data }) => {
         <ValueRow label="Reserve Shortfall" value={results.reserveShortfall} currency highlight />
         <Note>
           HDHPs depend on a stocked HSA to offset surprise bills. Direct premium savings into the account until the reserve
-          matches your deductible, then invest additional dollars for future medical needs.
+          matches your deductible, then invest extra dollars for future medical needs.
         </Note>
       </Section>
 

--- a/client/src/lib/pdf/use-pdf-export.ts
+++ b/client/src/lib/pdf/use-pdf-export.ts
@@ -37,10 +37,10 @@ export const usePDFExport = () => {
         results,
         additionalData: {
           narrative: {
-            compatibility: `Qualified ${coverageText} HDHP coverage unlocks ${formatCurrency(results.annualContributionLimit)} of annual HSA capacity, including ${formatCurrency(results.catchUpContribution ?? 0)} in catch-up room.`,
-            employerSupport: `Employer contributions of ${formatCurrency(results.employerContribution)} combine with your payroll deferrals to reach the ${formatCurrency(inputs.targetReserve)} reserve target.`,
-            premiumOffsets: `Switching plans frees ${formatCurrency(results.annualPremiumSavings)} in annual premiums that can be redirected to the HSA.`,
-            cashflow: `Net cashflow advantage of ${formatCurrency(results.netCashflowAdvantage)} blends premium savings, employer seeding, and tax benefits to blunt deductible exposure.`
+            compatibility: `Qualified ${coverageText} high-deductible health plan (HDHP) coverage opens ${formatCurrency(results.annualContributionLimit)} of health savings account (HSA) room, including ${formatCurrency(results.catchUpContribution ?? 0)} in catch-up space once you turn 55.`,
+            employerSupport: `Employer contributions of ${formatCurrency(results.employerContribution)} combine with your paycheck deposits to build the ${formatCurrency(inputs.targetReserve)} safety cushion.`,
+            premiumOffsets: `Switching plans frees ${formatCurrency(results.annualPremiumSavings)} in yearly premiums that can move straight into the HSA.`,
+            cashflow: `After premium savings, employer help, and tax savings, you keep ${formatCurrency(results.netCashflowAdvantage)} more than the payroll contributions going out.`,
           }
         }
       };

--- a/client/src/pages/calculator-hub.tsx
+++ b/client/src/pages/calculator-hub.tsx
@@ -18,7 +18,8 @@ export default function CalculatorHub() {
     {
       id: "hsa",
       title: "HSA Strategy Planner",
-      description: "Pair your HDHP with employer seeding, premium offsets, and a deductible reserve strategy so the account stays future-ready.",
+      description:
+        "See how a high-deductible health plan (HDHP) and health savings account (HSA) can share costs by mapping premium differences, employer contributions, and an emergency medical cushion.",
       icon: HeartPulse,
       route: "/hsa",
       analyticsId: "calculator-hsa-entry",

--- a/client/src/pages/comparison-tool.tsx
+++ b/client/src/pages/comparison-tool.tsx
@@ -37,9 +37,9 @@ const normaliseCalculatorId = (id: CalculatorType): CalculatorId => {
 const calculatorTypes = [
   {
     id: 'hsa' as const,
-    name: 'HSA Strategy',
+    name: 'Health Savings Account (HSA)',
     icon: HeartPulse,
-    description: 'Compare HDHP premium savings and HSA reserve strategies'
+    description: 'Compare high-deductible health plan (HDHP) premiums and HSA contributions in plain dollars'
   },
   {
     id: 'fsa' as const,

--- a/client/src/pages/hsa-calculator.tsx
+++ b/client/src/pages/hsa-calculator.tsx
@@ -81,9 +81,9 @@ export default function HSACalculator() {
               HSA Strategy Planner
             </h2>
             <p className="text-muted-foreground max-w-xl">
-              Map out how your high-deductible health plan and health savings account work together. HDHPs typically skip
-              copays and lean on HSA dollars to blunt the impact of higher deductibles—plan your funding so premiums and
-              reserves both pull their weight.
+              Use this guide to see how a high-deductible health plan (HDHP) works with a health savings account (HSA).
+              HDHPs usually skip copays, so you pay the early bills out of pocket. We will show how premiums, payroll
+              deposits, and any employer help can build an HSA cushion before those bills arrive.
             </p>
           </div>
         </div>
@@ -98,19 +98,20 @@ export default function HSACalculator() {
           <GlassCard className="space-y-6">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h3 className="text-xl font-semibold text-foreground">HDHP fit check</h3>
+                <h3 className="text-xl font-semibold text-foreground">Confirm HDHP eligibility</h3>
                 <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-                  Confirm the HDHP you are considering qualifies you for HSA access and captures your household needs.
-                  HDHPs trade predictable copays for lower premiums, so you want to size your HSA to catch the surprise
-                  bills.
+                  Make sure the plan you are choosing counts as an HDHP so you can fund an HSA. These plans trade
+                  predictable copays for lower premiums, so double-check that the coverage fits your household and that
+                  your HSA can handle unexpected bills.
                 </p>
               </div>
               <Tooltip
                 title="Why eligibility matters"
                 content={
                   <p>
-                    You can only fund an HSA while covered by a qualified high-deductible health plan. Coverage level and
-                    age determine your annual limit, and catch-up dollars unlock at age 55.
+                    You can only add money to an HSA while you have a qualified high-deductible health plan. The IRS sets
+                    your yearly limit by your coverage level and age, and people 55 or older can contribute an extra
+                    $1,000 catch-up amount.
                   </p>
                 }
               />
@@ -138,7 +139,7 @@ export default function HSACalculator() {
                       <div className="text-center">
                         <div className="text-primary text-xl mb-2">👤</div>
                         <div className="font-medium text-foreground">Individual</div>
-                        <div className="text-xs text-muted-foreground">Self-only HDHP</div>
+                        <div className="text-xs text-muted-foreground">Self-only HDHP coverage</div>
                       </div>
                     </Label>
                   </div>
@@ -154,7 +155,7 @@ export default function HSACalculator() {
                       <div className="text-center">
                         <div className="text-primary text-xl mb-2">👨‍👩‍👧‍👦</div>
                         <div className="font-medium text-foreground">Family</div>
-                        <div className="text-xs text-muted-foreground">Spouse and/or dependents</div>
+                        <div className="text-xs text-muted-foreground">Includes spouse and/or dependents</div>
                       </div>
                     </Label>
                   </div>
@@ -217,8 +218,8 @@ export default function HSACalculator() {
                 2025 contribution room: {formatCurrency(contributionLimit)}
               </p>
               <p className="text-muted-foreground mt-1">
-                Base limit of {formatCurrency(inputs.coverage === "family" ? HSA_LIMITS.family : HSA_LIMITS.individual)} plus
-                {inputs.age >= 55 ? "a $1,000 catch-up allowance." : "optional $1,000 catch-up once you turn 55."}
+                This includes the base limit of {formatCurrency(inputs.coverage === "family" ? HSA_LIMITS.family : HSA_LIMITS.individual)}
+                and {inputs.age >= 55 ? "a $1,000 catch-up contribution available after age 55." : "an extra $1,000 catch-up contribution once you reach age 55."}
               </p>
             </div>
           </GlassCard>
@@ -226,18 +227,18 @@ export default function HSACalculator() {
           <GlassCard className="space-y-8">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h3 className="text-xl font-semibold text-foreground">Fund your safety net</h3>
+                <h3 className="text-xl font-semibold text-foreground">Plan your HSA deposits</h3>
                 <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-                  Decide how many of your HSA dollars come from payroll vs. employer seed money. Your goal is to build a
-                  cushion that can handle the plan deductible without wrecking your cash flow.
+                  Decide how much to send from your paycheck and how much your employer adds. Together these deposits
+                  should build a cushion that can handle the plan deductible without wrecking your monthly budget.
                 </p>
               </div>
               <Tooltip
                 title="Why the slider matters"
                 content={
                   <p>
-                    Every pre-tax dollar you contribute shields income from taxes and builds the reserve you will lean on when
-                    a large bill arrives. Adjust the slider to balance take-home pay with peace of mind.
+                    Every pre-tax dollar you contribute avoids taxes today and grows the reserve you can tap when a large
+                    medical bill arrives. Adjust the slider to balance take-home pay with peace of mind.
                   </p>
                 }
               />
@@ -270,7 +271,8 @@ export default function HSACalculator() {
                   onChange={(event) => updateInput("employerSeed", Number(event.target.value) || 0)}
                 />
                 <p className="text-xs text-muted-foreground mt-2">
-                  Include any upfront seed or matching dollars that land in your HSA.
+                  Add any money your employer places in the HSA, whether it shows up at the start of the year or in
+                  matching deposits.
                 </p>
               </div>
               <div>
@@ -285,7 +287,7 @@ export default function HSACalculator() {
                   onChange={(event) => updateInput("targetReserve", Number(event.target.value) || 0)}
                 />
                 <p className="text-xs text-muted-foreground mt-2">
-                  Aim for your HDHP deductible or the amount that lets you sleep at night.
+                  Aim for an amount that covers your HDHP deductible or whatever balance would let you sleep at night.
                 </p>
               </div>
             </div>
@@ -294,18 +296,18 @@ export default function HSACalculator() {
           <GlassCard className="space-y-6">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h3 className="text-xl font-semibold text-foreground">Compare premiums</h3>
+                <h3 className="text-xl font-semibold text-foreground">Compare monthly premiums</h3>
                 <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-                  Stack the HDHP premium against the copay-friendly plan you are replacing. Premium savings are the cash
-                  stream you redirect toward funding the higher deductible.
+                  Stack the HDHP premium against the copay-friendly plan you are replacing. The monthly difference becomes
+                  the cash you can redirect into the HSA for future medical bills.
                 </p>
               </div>
               <Tooltip
                 title="Premium comparison"
                 content={
                   <p>
-                    HDHP premiums are typically lower each month. Multiply that gap by twelve to see how much budget you free
-                    up to send into your HSA.
+                    HDHP premiums are typically lower each month. Multiply that gap by twelve to see how much money you free
+                    up to send into your HSA for medical expenses.
                   </p>
                 }
               />
@@ -354,21 +356,22 @@ export default function HSACalculator() {
                 <p className="text-sm text-muted-foreground">Annual premium savings redirected</p>
                 <p className="text-2xl font-bold text-primary">{formatCurrency(premiumDifference)}</p>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Difference between your HDHP and alternative plan premiums for the full year.
+                  Total yearly difference between your HDHP premium and the alternative plan premium.
                 </p>
               </div>
               <div className="rounded-xl border border-emerald-300/40 bg-emerald-500/10 p-4">
                 <p className="text-sm text-muted-foreground">Projected HSA reserve after contributions</p>
                 <p className="text-2xl font-bold text-emerald-500">{formatCurrency(reserveProgress)}</p>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Employer dollars plus your pre-tax contributions available for medical surprises.
+                  Employer contributions plus your pre-tax deposits available to handle medical surprises.
                 </p>
               </div>
               <div className="rounded-xl border border-border p-4">
                 <p className="text-sm text-muted-foreground">Net cashflow advantage</p>
                 <p className="text-2xl font-bold text-foreground">{formatCurrency(results.netCashflowAdvantage)}</p>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Premium savings + employer seed + tax savings − your payroll contributions.
+                  The amount you keep after combining premium savings, employer contributions, and tax savings, then
+                  subtracting your payroll deposits.
                 </p>
               </div>
             </div>
@@ -388,7 +391,7 @@ export default function HSACalculator() {
           <ShowMathSection
             title="See how the dollars work"
             focusLabel="Premium savings vs. deductible readiness"
-            description="Trace how lower premiums, tax savings, and employer seed money come together to keep your HDHP affordable while you stockpile a deductible-sized buffer."
+            description="Trace how lower premiums, tax savings, and employer contributions come together to keep your HDHP affordable while you build a deductible-sized buffer."
             items={[
               {
                 label: "Annual premium gap",
@@ -405,7 +408,7 @@ export default function HSACalculator() {
               {
                 label: "Employer dollars",
                 value: formatCurrency(results.employerContribution),
-                helperText: "Seed money that immediately boosts your medical safety net.",
+                helperText: "Money your employer adds to the HSA to boost your medical safety net.",
               },
               {
                 label: "Projected reserve vs. goal",
@@ -436,7 +439,7 @@ export default function HSACalculator() {
             <p className="text-sm text-muted-foreground leading-relaxed">
               Remember: HDHPs rarely include copays for office visits or prescriptions. Expect to pay the negotiated rate
               until you hit the deductible, then lean on your HSA balance. Revisit this plan after open enrollment or if
-              your medical usage spikes mid-year.
+              your medical usage changes during the year.
             </p>
           </GlassCard>
         </div>


### PR DESCRIPTION
## Summary
- spell out high-deductible health plan (HDHP) and health savings account (HSA) terminology on the calculator hub and comparison selector
- rewrite the HSA calculator, comparison table, and benefit facts to use plain-language explanations and define key terms
- refresh the HSA PDF template and export narrative so every section explains jargon in everyday wording

## Testing
- not run (text-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68d6c4e4bfa883208675e5eaa4ab4b7d