### PR TITLE
Rewrite FSA content with plain-language explanations

### DIFF
--- a/client/src/components/comparisons/fsa-comparison.tsx
+++ b/client/src/components/comparisons/fsa-comparison.tsx
@@ -112,7 +112,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
         <div className="text-center py-8">
           <Calculator className="mx-auto text-muted-foreground mb-4" size={48} />
           <p className="text-muted-foreground">
-            Add FSA scenarios above to compare elections, grace periods, and forfeiture risk.
+            Add Flexible Spending Account scenarios above to compare elections, grace periods, and how much money could be forfeited.
           </p>
         </div>
       </GlassCard>
@@ -141,7 +141,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
   return (
     <div className="space-y-8">
       <GlassCard>
-        <h3 className="text-lg font-semibold text-foreground mb-6">FSA Scenario Summary</h3>
+        <h3 className="text-lg font-semibold text-foreground mb-6">FSA scenario snapshot</h3>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
@@ -156,7 +156,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
             </thead>
             <tbody>
               <tr className="border-b border-border">
-                <td className="p-3 font-medium text-foreground">Health FSA Election</td>
+                <td className="p-3 font-medium text-foreground">Health FSA election</td>
                 {summaryMetrics.map((metric) => (
                   <td key={`election-${metric.id}`} className="p-3 text-center">
                     {currency(metric.healthElection)}
@@ -164,7 +164,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                 ))}
               </tr>
               <tr className="border-b border-border">
-                <td className="p-3 font-medium text-foreground">Expected Utilisation</td>
+                <td className="p-3 font-medium text-foreground">Expected spending</td>
                 {summaryMetrics.map((metric) => (
                   <td key={`util-${metric.id}`} className="p-3 text-center">
                     <div className="flex items-center justify-center">
@@ -175,7 +175,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                 ))}
               </tr>
               <tr className="border-b border-border">
-                <td className="p-3 font-medium text-foreground">Carryover Utilised</td>
+                <td className="p-3 font-medium text-foreground">Carryover or grace protection</td>
                 {summaryMetrics.map((metric) => (
                   <td key={`carryover-${metric.id}`} className="p-3 text-center">
                     <div className="flex items-center justify-center">
@@ -186,7 +186,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                 ))}
               </tr>
               <tr className="border-b border-border">
-                <td className="p-3 font-medium text-foreground">Forfeiture Risk</td>
+                <td className="p-3 font-medium text-foreground">Money at risk of forfeiture</td>
                 {summaryMetrics.map((metric) => (
                   <td key={`forfeit-${metric.id}`} className="p-3 text-center">
                     <div className="flex items-center justify-center">
@@ -197,7 +197,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                 ))}
               </tr>
               <tr>
-                <td className="p-3 font-medium text-foreground">Net Benefit (Tax Savings − Risk)</td>
+                <td className="p-3 font-medium text-foreground">Net benefit after possible forfeiture</td>
                 {summaryMetrics.map((metric) => (
                   <td key={`benefit-${metric.id}`} className="p-3 text-center">
                     <div className="flex items-center justify-center">
@@ -224,7 +224,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
               <div className="flex items-start justify-between border-b border-border pb-2">
                 <div>
                   <h4 className="text-lg font-semibold text-foreground">{scenario.name}</h4>
-                  <p className="text-xs text-muted-foreground">Plan for eligible expenses and carryover rules</p>
+                  <p className="text-xs text-muted-foreground">Outline expected bills and the rules that help you avoid losing funds</p>
                 </div>
                 <Button
                   variant="ghost"
@@ -245,8 +245,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                       title="Election sizing"
                       content={
                         <p>
-                          Align the election with known medical bills. Any dollars beyond carryover and grace-period rules
-                          are forfeited back to the plan.
+                          Choose an election that matches medical bills you can name now. Money above what you spend or keep under the rules goes back to the plan.
                         </p>
                       }
                     />
@@ -271,11 +270,10 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                   <div className="flex items-center justify-between">
                     <Label className="text-sm font-medium text-foreground">Eligible expense buckets</Label>
                     <Tooltip
-                      title="Track expected spend"
+                      title="Track expected spending"
                       content={
                         <p>
-                          Break expenses into predictable categories so you can see how much of the election is spoken for
-                          before relying on carryover rules.
+                          Split your forecast into simple buckets. When most of the election is tied to real bills, you rely less on carryover or grace rules to save leftovers.
                         </p>
                       }
                     />
@@ -311,7 +309,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                   </div>
                   <div className="rounded-lg bg-primary/5 border border-dashed border-primary/40 p-3 text-xs text-muted-foreground">
                     <p>Expected eligible spend: {currency(scenario.data.expectedEligibleExpenses)}</p>
-                    <p>Carryover cushion: {currency(results?.carryoverProtected ?? 0)} • Forfeiture risk: {currency(results?.forfeitureRisk ?? 0)}</p>
+                    <p>Carryover or grace cushion: {currency(results?.carryoverProtected ?? 0)} • At risk of forfeiture: {currency(results?.forfeitureRisk ?? 0)}</p>
                   </div>
                 </div>
 
@@ -319,11 +317,10 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                   <div className="flex items-center justify-between">
                     <Label className="text-sm font-medium text-foreground">Carryover & grace rules</Label>
                     <Tooltip
-                      title="Grace period usage"
+                      title="Carryover and grace timing"
                       content={
                         <p>
-                          Document how long you have to spend remaining dollars after year-end. More time reduces forfeiture
-                          risk if your expenses arrive late.
+                          Write down how much can roll forward and how long you have to spend last year's dollars. Extra time or rollover space lowers the chance of losing money.
                         </p>
                       }
                     />
@@ -353,7 +350,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                         <span>0 months</span>
                         <span>3 months</span>
                       </div>
-                      <p className="text-xs text-muted-foreground mt-1">You have {gracePeriodDisplay} to spend on prior-year expenses.</p>
+                      <p className="text-xs text-muted-foreground mt-1">You have {gracePeriodDisplay} to spend on last year's eligible expenses.</p>
                     </div>
                   </div>
                 </div>
@@ -388,7 +385,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                       </Select>
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      Estimated marginal tax rate: <span className="font-semibold text-foreground">{scenarioResults[scenario.id]?.marginalRate ?? 0}%</span>
+                      Estimated marginal tax rate: <span className="font-semibold text-foreground">{scenarioResults[scenario.id]?.marginalRate ?? 0}%</span>. Each pre-tax dollar saves roughly this percentage in taxes.
                     </p>
                   </div>
 
@@ -396,7 +393,7 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                     <div className="flex items-center justify-between">
                       <div>
                         <Label className="text-sm font-medium text-foreground">Dependent-care FSA</Label>
-                        <p className="text-xs text-muted-foreground">Payroll reimbursements as expenses occur</p>
+                        <p className="text-xs text-muted-foreground">Money is reimbursed after you submit receipts for care</p>
                       </div>
                       <Switch
                         checked={scenario.data.includeDependentCare}
@@ -438,14 +435,14 @@ export default function FSAComparison({ scenarios, onUpdateScenario, onRemoveSce
                           />
                         </div>
                         <div className="rounded-lg bg-secondary/10 border border-dashed border-secondary/40 p-3 text-xs text-muted-foreground">
-                          <p>Tax savings: {currency(results?.dependentCareTaxSavings ?? 0)}</p>
-                          <p>Forfeiture risk: {currency(results?.dependentCareForfeitureRisk ?? 0)}</p>
+                          <p>Estimated tax savings: {currency(results?.dependentCareTaxSavings ?? 0)}</p>
+                          <p>Money at risk of forfeiture: {currency(results?.dependentCareForfeitureRisk ?? 0)}</p>
                         </div>
                       </div>
                     ) : (
                       <div className="flex items-center gap-2 text-xs text-muted-foreground">
                         <AlertTriangle size={14} className="text-amber-500" />
-                        <span>Enable dependent-care to compare childcare reimbursements.</span>
+                        <span>Enable dependent-care to compare how childcare reimbursements change your taxes.</span>
                       </div>
                     )}
                   </div>

--- a/client/src/lib/benefitFacts.ts
+++ b/client/src/lib/benefitFacts.ts
@@ -24,9 +24,18 @@ export const BENEFIT_FACTS: Record<CalculatorId, BenefitFact[]> = {
     },
   ],
   fsa: [
-    { label: "Health FSA Limit:", value: formatCurrency(CONTRIBUTION_LIMITS.FSA) },
-    { label: "Use-it-or-lose-it:", value: "Forfeit amounts beyond carryover/grace" },
-    { label: "Dependent Care Max:", value: formatCurrency(FSA_LIMITS.dependentCare) },
+    {
+      label: "Health FSA annual limit (2025):",
+      value: `${formatCurrency(CONTRIBUTION_LIMITS.FSA)} you can pledge for eligible medical costs this plan year`,
+    },
+    {
+      label: '"Use-it-or-lose-it" rule:',
+      value: "Spend the money by the deadline or give it back—only carryover or a grace period protects leftovers",
+    },
+    {
+      label: "Dependent-care FSA household limit (2025):",
+      value: `${formatCurrency(FSA_LIMITS.dependentCare)} shared across the household for childcare or elder care reimbursements`,
+    },
   ],
   commuter: [
     { label: "Transit Limit:", value: `${formatCurrency(CONTRIBUTION_LIMITS.COMMUTER_TRANSIT)}/month` },

--- a/client/src/lib/pdf/templates/fsa-report.tsx
+++ b/client/src/lib/pdf/templates/fsa-report.tsx
@@ -25,48 +25,54 @@ export const FSAReport: React.FC<FSAReportProps> = ({ data }) => {
   return (
     <BaseDocument title="FSA Election Analysis" subtitle="Health & Dependent Care FSAs - Tax Year 2025" generatedAt={generatedAt}>
       <Section title="Executive Summary">
+        <Text style={{ fontSize: 10, marginBottom: 10, color: '#374151' }}>
+          This report breaks down your Flexible Spending Account choices in everyday language. Use it to confirm how much you elected, what you plan to spend, and how the use-it-or-lose-it rule could affect you.
+        </Text>
         <MetricGrid>
           <MetricCard
             title="Health FSA Election"
             value={inputs.healthElection}
             currency
-            description="Total annual amount elected"
+            description="Total dollars you promised to set aside this year"
           />
           <MetricCard
-            title="Expected Utilisation"
+            title="Planned spending"
             value={results.expectedUtilization}
             currency
-            description="Projected spend within plan rules"
+            description="What you expect to spend under plan rules"
           />
           <MetricCard
             title="Tax Savings"
             value={results.taxSavings}
             currency
-            description="Payroll tax reduction"
+            description="Estimated taxes you avoid with pre-tax dollars"
           />
           <MetricCard
-            title="Forfeiture Risk"
+            title="Money at risk"
             value={results.forfeitureRisk}
             currency
-            description="Potential unused balance"
+            description="Amount you could forfeit if left unspent"
           />
         </MetricGrid>
       </Section>
 
       <Divider />
 
-      <Section title="Plan Inputs">
-        <ValueRow label="Health FSA Election" value={inputs.healthElection} currency />
-        <ValueRow label="Expected Eligible Expenses" value={inputs.expectedEligibleExpenses} currency />
-        <ValueRow label="Carryover Allowance" value={inputs.planCarryover} currency />
-        <ValueRow label="Grace Period" value={`${inputs.gracePeriodMonths.toFixed(1)} months`} />
-        <ValueRow label="Household Annual Income" value={inputs.annualIncome} currency />
-        <ValueRow label="Marginal Tax Rate" value={`${results.marginalRate}%`} />
-        <ValueRow label="Dependent-care Included" value={inputs.includeDependentCare ? 'Yes' : 'No'} />
+      <Section title="What we used for the math">
+        <Text style={{ fontSize: 10, marginBottom: 8, color: '#374151' }}>
+          These are the numbers you entered or that apply to your plan. They drive the savings and forfeiture estimates in this report.
+        </Text>
+        <ValueRow label="Health FSA election (total pledged)" value={inputs.healthElection} currency />
+        <ValueRow label="Expected eligible expenses" value={inputs.expectedEligibleExpenses} currency />
+        <ValueRow label="Carryover allowance" value={inputs.planCarryover} currency />
+        <ValueRow label="Grace period length" value={`${inputs.gracePeriodMonths.toFixed(1)} months`} />
+        <ValueRow label="Household annual income" value={inputs.annualIncome} currency />
+        <ValueRow label="Estimated marginal tax rate" value={`${results.marginalRate}%`} />
+        <ValueRow label="Dependent-care FSA included" value={inputs.includeDependentCare ? 'Yes' : 'No'} />
         {inputs.includeDependentCare ? (
           <>
-            <ValueRow label="Dependent-care Election" value={inputs.dependentCareElection} currency />
-            <ValueRow label="Expected Dependent-care Expenses" value={inputs.expectedDependentCareExpenses} currency />
+            <ValueRow label="Dependent-care election (household total)" value={inputs.dependentCareElection} currency />
+            <ValueRow label="Expected dependent-care expenses" value={inputs.expectedDependentCareExpenses} currency />
           </>
         ) : null}
       </Section>
@@ -75,6 +81,9 @@ export const FSAReport: React.FC<FSAReportProps> = ({ data }) => {
 
       {talkingPoints ? (
         <Section title="Election Storyline">
+          <Text style={{ fontSize: 10, marginBottom: 8, color: '#374151' }}>
+            Here is the plain-language summary pulled from your inputs. Share these bullets with your benefits team or keep them for open enrollment notes.
+          </Text>
           {talkingPoints.electionSizing && (
             <Text style={{ fontSize: 9, marginBottom: 6, color: '#374151' }}>{`• ${talkingPoints.electionSizing}`}</Text>
           )}
@@ -91,26 +100,25 @@ export const FSAReport: React.FC<FSAReportProps> = ({ data }) => {
 
       <Section title="Health FSA Forecast">
         <Text style={{ fontSize: 10, marginBottom: 10, color: '#374151' }}>
-          Health FSA dollars are available at the start of the plan year. Align your election with known procedures and
-          everyday copays to minimise forfeiture risk.
+          Your health FSA election is ready on the first day of the plan year even if you have not paid in yet. Use the numbers below to see how well your election matches known bills and how much the use-it-or-lose-it rule might affect you.
         </Text>
-        <ValueRow label="Election vs. Expected Spend" value={`${formatCurrency(inputs.healthElection)} / ${formatCurrency(inputs.expectedEligibleExpenses)}`} />
-        <ValueRow label="Carryover Protected" value={results.carryoverProtected} currency />
-        <ValueRow label="Potential Forfeiture" value={results.forfeitureRisk} currency highlight />
-        <ValueRow label="Net Benefit (Tax Savings − Risk)" value={results.netBenefit} currency primary />
+        <ValueRow label="Election compared with expected bills" value={`${formatCurrency(inputs.healthElection)} / ${formatCurrency(inputs.expectedEligibleExpenses)}`} />
+        <ValueRow label="Carryover or grace protection" value={results.carryoverProtected} currency />
+        <ValueRow label="Money that could be forfeited" value={results.forfeitureRisk} currency highlight />
+        <ValueRow label="Net benefit after possible forfeiture" value={results.netBenefit} currency primary />
       </Section>
 
       <Divider />
 
       {inputs.includeDependentCare ? (
         <Section title="Dependent-care FSA Snapshot">
-          <ValueRow label="Election" value={inputs.dependentCareElection} currency />
-          <ValueRow label="Expected Expenses" value={inputs.expectedDependentCareExpenses} currency />
-          <ValueRow label="Tax Savings" value={results.dependentCareTaxSavings} currency />
-          <ValueRow label="Potential Forfeiture" value={results.dependentCareForfeitureRisk} currency highlight />
+          <ValueRow label="Election (shared household total)" value={inputs.dependentCareElection} currency />
+          <ValueRow label="Expected dependent-care bills" value={inputs.expectedDependentCareExpenses} currency />
+          <ValueRow label="Estimated tax savings" value={results.dependentCareTaxSavings} currency />
+          <ValueRow label="Money that could be forfeited" value={results.dependentCareForfeitureRisk} currency highlight />
           <Note>
-            Dependent-care FSAs reimburse as you contribute. Submit receipts regularly to avoid leaving reimbursements on
-            the table, and coordinate with your spouse so household elections stay within IRS limits.
+            Dependent-care FSA dollars build up each payday and are reimbursed only after you pay the provider. Submit
+            receipts regularly and coordinate with your spouse so the household stays under the IRS limit.
           </Note>
         </Section>
       ) : null}
@@ -121,17 +129,9 @@ export const FSAReport: React.FC<FSAReportProps> = ({ data }) => {
         <Text style={{ fontSize: 10, marginBottom: 6, color: '#374151' }}>
           Use these suggestions to fine-tune your election and stay aligned with plan rules:
         </Text>
-        <Text style={{ fontSize: 9, marginBottom: 4, color: '#374151' }}>
-          • If expected expenses are lower than your election, reduce the election or plan eligible purchases before the
-          year closes.
-        </Text>
-        <Text style={{ fontSize: 9, marginBottom: 4, color: '#374151' }}>
-          • Track reimbursements throughout the year to keep cash flowing and avoid a rush during the grace period.
-        </Text>
-        <Text style={{ fontSize: 9, color: '#374151' }}>
-          • Coordinate health FSAs with HSAs or copay-based plans—only one spouse can elect a full health FSA if the other
-          contributes to an HSA.
-        </Text>
+        <Text style={{ fontSize: 9, marginBottom: 4, color: '#374151' }}>• If expected expenses are lower than your election, lower the election or schedule eligible purchases before deadlines.</Text>
+        <Text style={{ fontSize: 9, marginBottom: 4, color: '#374151' }}>• Submit claims during the year so reimbursements keep pace with spending and you are not rushing at year-end.</Text>
+        <Text style={{ fontSize: 9, color: '#374151' }}>• Coordinate with your spouse's benefits—only one person can have a full health FSA if the other contributes to a health savings account.</Text>
       </Section>
     </BaseDocument>
   );

--- a/client/src/lib/pdf/use-pdf-export.ts
+++ b/client/src/lib/pdf/use-pdf-export.ts
@@ -69,9 +69,9 @@ export const usePDFExport = () => {
         results,
         additionalData: {
           narrative: {
-            electionSizing: `Health FSA election of ${formatCurrency(inputs.healthElection)} captures ${formatCurrency(results.expectedUtilization)} in expected expenses across routine care, planned procedures, and prescriptions.`,
-            gracePeriod: `Carryover allowances protect ${formatCurrency(results.carryoverProtected)} with a ${inputs.gracePeriodMonths.toFixed(1)}-month grace period to finish spending prior-year dollars.`,
-            forfeiture: `Monitor ${formatCurrency(results.forfeitureRisk)} of potential forfeitures and adjust before year-end to preserve the ${formatCurrency(results.netBenefit)} net benefit after taxes.`
+            electionSizing: `You chose to set aside ${formatCurrency(inputs.healthElection)}. That amount should cover about ${formatCurrency(results.expectedUtilization)} in medical costs you already expect, such as routine visits and prescriptions.`,
+            gracePeriod: `Your plan protects roughly ${formatCurrency(results.carryoverProtected)} through carryover rules and a ${inputs.gracePeriodMonths.toFixed(1)}-month grace period, giving extra time to spend leftovers.`,
+            forfeiture: `Keep an eye on the ${formatCurrency(results.forfeitureRisk)} that could be forfeited so you hold on to the ${formatCurrency(results.netBenefit)} net benefit after taxes.`
           }
         }
       };

--- a/client/src/pages/calculator-hub.tsx
+++ b/client/src/pages/calculator-hub.tsx
@@ -27,7 +27,8 @@ export default function CalculatorHub() {
     {
       id: "fsa",
       title: "FSA Election Forecaster",
-      description: "Model health and dependent-care elections with carryover rules and avoid forfeiting dollars under use-it-or-lose-it policies.",
+      description:
+        "Plan Flexible Spending Account elections with clear guardrails so you understand how much can carry into next year and how the use-it-or-lose-it rule works.",
       icon: ClipboardList,
       route: "/fsa",
       analyticsId: "calculator-fsa-entry",

--- a/client/src/pages/comparison-tool.tsx
+++ b/client/src/pages/comparison-tool.tsx
@@ -45,7 +45,7 @@ const calculatorTypes = [
     id: 'fsa' as const,
     name: 'FSA Forecast',
     icon: ClipboardList,
-    description: 'Compare election sizing, grace periods, and forfeiture exposure'
+    description: 'Compare Flexible Spending Account elections, carryover cushions, and what happens under the use-it-or-lose-it rule'
   },
   {
     id: 'commuter' as const,

--- a/client/src/pages/fsa-calculator.tsx
+++ b/client/src/pages/fsa-calculator.tsx
@@ -71,9 +71,9 @@ export default function FSACalculator() {
               FSA Election Forecaster
             </h2>
             <p className="text-muted-foreground max-w-xl">
-              Forecast medical and dependent-care expenses so you can elect the right FSA amounts. FSAs give you the
-              full-year election on day one, but unused dollars are forfeited—pair the upfront access with realistic
-              expense planning.
+              A Flexible Spending Account lets you choose an annual election, get the full balance on day one, and pay
+              back the money through paychecks. This planner explains how the use-it-or-lose-it rule, carryovers, and
+              grace periods work so you only set aside what you can spend.
             </p>
           </div>
         </div>
@@ -88,20 +88,20 @@ export default function FSACalculator() {
           <GlassCard className="space-y-6">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h3 className="text-xl font-semibold text-foreground">Plan-year blueprint</h3>
+                <h3 className="text-xl font-semibold text-foreground">Plan your yearly election</h3>
                 <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-                  Choose how much to lock into your health FSA and map out when those dollars will be needed. Because the
-                  entire election is available on the first day of the plan year, align your forecast with surgeries,
-                  pregnancies, therapy, or prescriptions you know are coming.
+                  Decide how much money to promise to the health FSA for the year. You can swipe the card or request a
+                  reimbursement for the full election even if only a few paychecks have been taken so far. Match that
+                  upfront access with real appointments such as braces, prescriptions, or therapy visits.
                 </p>
               </div>
               <Tooltip
-                title="Front-loaded access"
+                title="Explain the election"
                 content={
                   <p>
-                    Health FSA elections are front-loaded—you can spend the full annual amount early in the plan year even
-                    though you have only contributed a few pay periods. Plan for that float while keeping forfeiture risk in
-                    check.
+                    Your election is the total dollars you promise to spend through the health FSA. The plan front-loads
+                    that money, so you can use all of it at once and repay it over the rest of the year. Keep that loan in
+                    mind when you size the election.
                   </p>
                 }
               />
@@ -132,7 +132,7 @@ export default function FSACalculator() {
                   onChange={(event) => updateInput("expectedEligibleExpenses", Number(event.target.value) || 0)}
                 />
                 <p className="text-xs text-muted-foreground mt-2">
-                  Add up copays, deductibles, glasses, dental work—anything your health plan does not fully cover.
+                  Add up copays, deductibles, glasses, dental work—any health bill you expect to pay out of pocket this year.
                 </p>
               </div>
 
@@ -170,7 +170,7 @@ export default function FSACalculator() {
                 </div>
 
                 <p className="text-xs text-muted-foreground">
-                  Estimated marginal tax rate: <span className="font-semibold text-foreground">{marginalRate}%</span>
+                  Estimated marginal tax rate: <span className="font-semibold text-foreground">{marginalRate}%</span>. Every FSA dollar avoids taxes at roughly this rate.
                 </p>
 
                 <div>
@@ -188,8 +188,8 @@ export default function FSACalculator() {
                       onChange={(event) => updateInput("planCarryover", Number(event.target.value) || 0)}
                     />
                     <p className="text-xs text-muted-foreground">
-                      Enter your plan's carryover allowance. If you have a grace period instead, set carryover to 0 and use
-                      the months slider below.
+                      Enter how much your plan lets you roll into the next year. If your plan only offers a grace period,
+                      set the carryover to 0 and adjust the months slider instead.
                     </p>
                     <DecisionSlider
                       id="grace-period"
@@ -200,7 +200,7 @@ export default function FSACalculator() {
                       step={0.5}
                       formatValue={(value) => `${value.toFixed(1)} months`}
                       onChange={(value) => updateInput("gracePeriodMonths", value)}
-                      helperText="How long after the plan year ends you can spend leftover dollars on prior-year expenses."
+                      helperText="Months after the plan year when you can still swipe your FSA card for last year's bills."
                       focusLabel="Plan-year timing"
                     />
                   </div>
@@ -212,18 +212,19 @@ export default function FSACalculator() {
           <GlassCard className="space-y-6">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h3 className="text-xl font-semibold text-foreground">Dependent-care coordination</h3>
+                <h3 className="text-xl font-semibold text-foreground">Add dependent-care savings</h3>
                 <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-                  If you have daycare, after-school, or elder-care bills, coordinate the dependent-care FSA alongside the
-                  medical FSA. The benefit is capped separately and follows the same use-it-or-lose-it rules.
+                  A dependent-care FSA covers daycare, summer camp, after-school programs, and certain elder care. It has
+                  its own household limit and also follows a use-it-or-lose-it rule, so line up the election with invoices
+                  you already pay.
                 </p>
               </div>
               <Tooltip
-                title="Limits work differently"
+                title="How this account pays you back"
                 content={
                   <p>
-                    Dependent-care FSA dollars are shared per household and capped at {currency(FSA_LIMITS.dependentCare)}.
-                    Elections are not available upfront—funds accumulate as you contribute through payroll.
+                    Families share one dependent-care FSA limit of {currency(FSA_LIMITS.dependentCare)}. Money builds each
+                    payday and can only be reimbursed after you have paid for care, so submit receipts often.
                   </p>
                 }
               />
@@ -233,7 +234,7 @@ export default function FSACalculator() {
               <div>
                 <p className="text-sm font-medium text-foreground">Include dependent-care FSA</p>
                 <p className="text-xs text-muted-foreground">
-                  Toggle on if you plan to set aside pre-tax dollars for child or elder care expenses.
+                  Turn this on if you expect to pay child or elder care that qualifies for pre-tax reimbursement.
                 </p>
               </div>
               <Switch
@@ -269,7 +270,7 @@ export default function FSACalculator() {
                     onChange={(event) => updateInput("expectedDependentCareExpenses", Number(event.target.value) || 0)}
                   />
                   <p className="text-xs text-muted-foreground mt-2">
-                    Include daycare, preschool, or qualified elder care costs you expect this year.
+                    Include daycare, preschool, day camps, after-school programs, or qualified elder care costs for this year.
                   </p>
                 </div>
               </div>
@@ -288,21 +289,21 @@ export default function FSACalculator() {
                 <p className="text-sm text-muted-foreground">Health FSA tax savings</p>
                 <p className="text-2xl font-bold text-primary">{currency(results.taxSavings)}</p>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Immediate payroll tax reduction from your health FSA election.
+                  Estimated taxes avoided because your election comes out of your paycheck before taxes.
                 </p>
               </div>
               <div className="rounded-xl border border-emerald-300/40 bg-emerald-500/10 p-4">
                 <p className="text-sm text-muted-foreground">Protected by carryover/grace</p>
                 <p className="text-2xl font-bold text-emerald-500">{currency(results.carryoverProtected)}</p>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Amount likely saved from forfeiture thanks to your plan's safety net.
+                  Dollars that should survive the use-it-or-lose-it rule because of your carryover or grace period.
                 </p>
               </div>
               <div className="rounded-xl border border-amber-300/40 bg-amber-500/10 p-4">
                 <p className="text-sm text-muted-foreground">Potential forfeiture risk</p>
                 <p className="text-2xl font-bold text-amber-500">{currency(results.forfeitureRisk)}</p>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Dollars at risk if spending runs below your election after grace/carryover buffers.
+                  Money you might lose back to the plan if you do not spend it by the deadline.
                 </p>
               </div>
               {inputs.includeDependentCare ? (
@@ -310,7 +311,7 @@ export default function FSACalculator() {
                   <p className="text-sm text-muted-foreground">Dependent-care tax savings</p>
                   <p className="text-2xl font-bold text-foreground">{currency(results.dependentCareTaxSavings)}</p>
                   <p className="text-xs text-muted-foreground mt-1">
-                    Withheld pre-tax to offset childcare or elder care invoices.
+                    Withheld before taxes so you are reimbursed for childcare or elder care bills.
                   </p>
                 </div>
               ) : null}
@@ -331,21 +332,21 @@ export default function FSACalculator() {
           <ShowMathSection
             title="Show the math"
             focusLabel="Forecast vs. IRS limits"
-            description="Compare what you plan to spend with what you elected so you can avoid forfeiting dollars while still enjoying the front-loaded access an FSA provides."
+            description="See how your planned bills line up with your election, the carryover cushion, and any money at risk of being lost."
             items={[
               {
                 label: "Health FSA election vs. forecast",
                 value: `${currency(inputs.healthElection)} elected / ${currency(inputs.expectedEligibleExpenses)} planned`,
                 helperText:
                   results.expectedUtilization < inputs.healthElection
-                    ? `${currency(inputs.healthElection - results.expectedUtilization)} may go unused unless carryover or a grace period saves it.`
-                    : "Your election matches the care you expect to receive—low forfeiture risk.",
+                    ? `${currency(inputs.healthElection - results.expectedUtilization)} could be lost unless your carryover or grace period saves it.`
+                    : "Your election matches the care you expect to receive, so little should be forfeited.",
                 accent: results.expectedUtilization < inputs.healthElection ? "warning" : "success",
               },
               {
-                label: "Carryover + grace coverage",
+                label: "Carryover and grace protection",
                 value: `${currency(results.carryoverProtected)} protected`,
-                helperText: "Set expectations for how much of any leftover funds your plan rules will allow you to keep.",
+                helperText: "Shows how much of any leftover balance should roll or stay available into the next year.",
                 accent: "primary",
               },
               {
@@ -353,8 +354,8 @@ export default function FSACalculator() {
                 value: currency(results.netBenefit),
                 helperText:
                   results.netBenefit >= 0
-                    ? "Positive numbers mean tax savings outpace potential forfeitures."
-                    : "If the number is negative, trim your election or accelerate eligible spending.",
+                    ? "If this is positive, your tax savings beat the dollars you might forfeit."
+                    : "If this is negative, lower the election or plan qualified spending before deadlines.",
                 accent: results.netBenefit >= 0 ? "success" : "warning",
               },
               ...(inputs.includeDependentCare
@@ -364,7 +365,7 @@ export default function FSACalculator() {
                       value: `${currency(inputs.dependentCareElection)} elected / ${currency(inputs.expectedDependentCareExpenses)} planned`,
                       helperText:
                         results.dependentCareForfeitureRisk > 0
-                          ? `${currency(results.dependentCareForfeitureRisk)} could be forfeited—double-check invoices or reduce the election.`
+                          ? `${currency(results.dependentCareForfeitureRisk)} could be lost—double-check invoices or lower the election.`
                           : "Your dependent-care election is covered by expected expenses.",
                       accent: results.dependentCareForfeitureRisk > 0 ? "warning" : "success",
                     },
@@ -379,9 +380,9 @@ export default function FSACalculator() {
               <h3 className="text-lg font-semibold text-foreground">Coordinate with your health plan</h3>
             </div>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              FSAs pair best with copay-based medical plans or HDHPs where you limit contributions. Track reimbursements
-              through the year so you do not leave money in the account at year end, and revisit elections if your plan
-              switches between carryover and grace period provisions.
+              Check how your health plan handles deductibles and copays before locking in an election. Track
+              reimbursements during the year so money does not sit unused, and ask HR if carryover or grace rules change
+              before you re-enroll.
             </p>
           </GlassCard>
         </div>


### PR DESCRIPTION
## Summary
- update the FSA hub and comparison picker tiles to describe Flexible Spending Accounts and the use-it-or-lose-it rule in plain language
- rewrite the FSA calculator, comparison table, and supporting fact strings so elections, carryovers, grace periods, and forfeiture risk are defined in simple sentences
- refresh the FSA PDF report template and narrative copy to mirror the new tone and terminology

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d6c658b45c8320b525024f79e5c287