### PR TITLE
Clarify commuter benefit guidance across UI and PDF

### DIFF
--- a/client/src/components/comparisons/commuter-comparison.tsx
+++ b/client/src/components/comparisons/commuter-comparison.tsx
@@ -92,7 +92,7 @@ export default function CommuterComparison({ scenarios, onUpdateScenario, onRemo
     <div className="space-y-8">
       {/* Results Comparison Table */}
       <GlassCard>
-        <h3 className="text-lg font-semibold text-foreground mb-6">Results Comparison</h3>
+        <h3 className="text-lg font-semibold text-foreground mb-6">Savings You Keep Each Year</h3>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
@@ -158,7 +158,7 @@ export default function CommuterComparison({ scenarios, onUpdateScenario, onRemo
 
       {/* Additional Results Details */}
       <GlassCard>
-        <h3 className="text-lg font-semibold text-foreground mb-6">Annual Spending Details</h3>
+        <h3 className="text-lg font-semibold text-foreground mb-6">What You Spend On Commuting</h3>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
@@ -238,7 +238,7 @@ export default function CommuterComparison({ scenarios, onUpdateScenario, onRemo
               <div>
                 <Label className="flex items-center text-sm font-medium text-foreground mb-3">
                   Monthly Transit Cost
-                  <Tooltip content="Include the monthly cost of eligible public transit for your commute—subways, buses, commuter rail, ferries, and employer-sponsored vanpools. The IRS allows up to $315 per month in 2025 to be set aside pre-tax; anything above that is paid with after-tax dollars." />
+                  <Tooltip content="Eligible expenses are the bus, train, subway, ferry, or employer vanpool rides you take to get to work. In 2025 you can move up to $315 per month from your paycheck before taxes for these rides; extra costs are paid with normal taxed pay." />
                 </Label>
                 <div className="space-y-3">
                   <div className="relative">
@@ -264,7 +264,7 @@ export default function CommuterComparison({ scenarios, onUpdateScenario, onRemo
                     />
                     <div className="flex justify-between text-xs text-muted-foreground mt-1">
                       <span>$0</span>
-                      <span>${CONTRIBUTION_LIMITS.COMMUTER_TRANSIT}/month limit</span>
+                      <span>${CONTRIBUTION_LIMITS.COMMUTER_TRANSIT}/month tax-free cap</span>
                     </div>
                   </div>
                 </div>
@@ -274,7 +274,7 @@ export default function CommuterComparison({ scenarios, onUpdateScenario, onRemo
               <div>
                 <Label className="flex items-center text-sm font-medium text-foreground mb-3">
                   Monthly Parking Cost
-                  <Tooltip content="Add what you spend to park at or near your workplace or a transit station. Only parking tied directly to your commute qualifies for the $315 per month pre-tax limit in 2025; general street parking or mileage reimbursement does not count." />
+                  <Tooltip content="Eligible parking means spots connected to your commute, like the lot at your office or the garage by the train station. You can set aside up to $315 per month before taxes in 2025; parking beyond that amount is treated like regular pay." />
                 </Label>
                 <div className="space-y-3">
                   <div className="relative">
@@ -300,7 +300,7 @@ export default function CommuterComparison({ scenarios, onUpdateScenario, onRemo
                     />
                     <div className="flex justify-between text-xs text-muted-foreground mt-1">
                       <span>$0</span>
-                      <span>${CONTRIBUTION_LIMITS.COMMUTER_PARKING}/month limit</span>
+                      <span>${CONTRIBUTION_LIMITS.COMMUTER_PARKING}/month tax-free cap</span>
                     </div>
                   </div>
                 </div>
@@ -344,7 +344,7 @@ export default function CommuterComparison({ scenarios, onUpdateScenario, onRemo
 
               {/* Quick Summary */}
               <div className="bg-background/50 rounded-lg p-4 space-y-2">
-                <div className="text-xs text-muted-foreground uppercase tracking-wide">Monthly Summary</div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wide">Monthly Snapshot</div>
                 <div className="space-y-1">
                   <div className="flex justify-between text-sm">
                     <span>Transit:</span>

--- a/client/src/lib/benefitFacts.ts
+++ b/client/src/lib/benefitFacts.ts
@@ -29,8 +29,14 @@ export const BENEFIT_FACTS: Record<CalculatorId, BenefitFact[]> = {
     { label: "Dependent Care Max:", value: formatCurrency(FSA_LIMITS.dependentCare) },
   ],
   commuter: [
-    { label: "Transit Limit:", value: `${formatCurrency(CONTRIBUTION_LIMITS.COMMUTER_TRANSIT)}/month` },
-    { label: "Parking Limit:", value: `${formatCurrency(CONTRIBUTION_LIMITS.COMMUTER_PARKING)}/month` },
+    {
+      label: "Transit limit (2025):",
+      value: `You can set aside up to ${formatCurrency(CONTRIBUTION_LIMITS.COMMUTER_TRANSIT)} each month before taxes for transit fares, passes, and vanpools tied to your commute`,
+    },
+    {
+      label: "Parking limit (2025):",
+      value: `You can also save up to ${formatCurrency(CONTRIBUTION_LIMITS.COMMUTER_PARKING)} per month before taxes for parking next to work or a transit station`,
+    },
   ],
   life: [
     { label: "Income Replacement:", value: "10-15x Annual" },

--- a/client/src/lib/pdf/templates/commuter-report.tsx
+++ b/client/src/lib/pdf/templates/commuter-report.tsx
@@ -65,22 +65,23 @@ export const CommuterReport: React.FC<CommuterReportProps> = ({ data }) => {
       <Divider />
 
       {/* 2025 Benefit Limits and Calculations */}
-      <Section title="2025 Benefit Limits & Tax Calculations">
+      <Section title="How the 2025 Limits Work">
         <Text style={{ fontSize: 10, marginBottom: 10, color: '#374151' }}>
-          Federal law allows pre-tax deductions for qualified transportation expenses up to monthly limits.
+          A monthly limit is the most you can move from your paycheck before taxes. For 2025 the IRS lets you set aside up to
+          {` ${formatCurrency(315)}`} for transit and another {` ${formatCurrency(315)}`} for parking each month.
         </Text>
-        
+
         <View style={{ marginBottom: 15 }}>
           <Text style={{ fontSize: 11, fontWeight: 'bold', marginBottom: 8, color: '#1f2937' }}>
-            Transit Benefits (Bus, Train, Subway, Ferry, Vanpool)
+            Transit rides that count (bus, train, subway, ferry, vanpool)
           </Text>
           <ValueRow label="Your Monthly Transit Cost" value={inputs.transitCost} currency />
-          <ValueRow label="2025 Monthly Limit" value={315} currency />
-          <ValueRow 
-            label="Eligible Monthly Amount" 
-            value={Math.min(inputs.transitCost, 315)} 
-            currency 
-            primary 
+          <ValueRow label="2025 monthly limit" value={315} currency />
+          <ValueRow
+            label="Amount you can set aside before taxes"
+            value={Math.min(inputs.transitCost, 315)}
+            currency
+            primary
           />
           <ValueRow label="Annual Transit Benefit" value={results.annualTransit} currency />
           <ValueRow
@@ -93,15 +94,15 @@ export const CommuterReport: React.FC<CommuterReportProps> = ({ data }) => {
 
         <View style={{ marginBottom: 15 }}>
           <Text style={{ fontSize: 11, fontWeight: 'bold', marginBottom: 8, color: '#1f2937' }}>
-            Parking Benefits (Workplace Parking)
+            Parking that counts (garage or lot tied to your commute)
           </Text>
           <ValueRow label="Your Monthly Parking Cost" value={inputs.parkingCost} currency />
-          <ValueRow label="2025 Monthly Limit" value={315} currency />
-          <ValueRow 
-            label="Eligible Monthly Amount" 
-            value={Math.min(inputs.parkingCost, 315)} 
-            currency 
-            primary 
+          <ValueRow label="2025 monthly limit" value={315} currency />
+          <ValueRow
+            label="Amount you can set aside before taxes"
+            value={Math.min(inputs.parkingCost, 315)}
+            currency
+            primary
           />
           <ValueRow label="Annual Parking Benefit" value={results.annualParking} currency />
           <ValueRow
@@ -130,98 +131,66 @@ export const CommuterReport: React.FC<CommuterReportProps> = ({ data }) => {
       <Divider />
 
       {/* Eligible Expenses */}
-      <Section title="Eligible Transportation Expenses">
+      <Section title="What Counts as an Eligible Expense">
+        <Text style={{ fontSize: 10, marginBottom: 10, color: '#374151' }}>
+          Eligible expenses are the commute costs directly tied to getting to work. Keep your passes and receipts—substantiation
+          just means you may need to show that proof to your benefit administrator.
+        </Text>
+
         <View style={{ marginBottom: 10 }}>
           <Text style={{ fontSize: 11, fontWeight: 'bold', marginBottom: 8, color: '#1f2937' }}>
-            Qualified Transit Expenses Include:
+            Covered transit examples
           </Text>
-          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-            • Bus, subway, train, and ferry fares
-          </Text>
-          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-            • Vanpool transportation to/from work
-          </Text>
-          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-            • Transit passes and tokens
-          </Text>
-          <Text style={{ fontSize: 9, marginBottom: 8, color: '#374151' }}>
-            • Stored value cards for transit systems
-          </Text>
+          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>• Bus, subway, train, and ferry fares</Text>
+          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>• Employer-sponsored or public vanpools</Text>
+          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>• Monthly passes, tokens, or stored-value cards you use to commute</Text>
         </View>
 
         <View style={{ marginBottom: 10 }}>
           <Text style={{ fontSize: 11, fontWeight: 'bold', marginBottom: 8, color: '#1f2937' }}>
-            Qualified Parking Expenses Include:
+            Covered parking examples
           </Text>
-          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-            • Parking at or near your workplace
-          </Text>
-          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-            • Parking at transit facilities for commuting
-          </Text>
-          <Text style={{ fontSize: 9, marginBottom: 8, color: '#374151' }}>
-            • Monthly or daily parking fees
-          </Text>
+          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>• Parking garages or lots next to your workplace</Text>
+          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>• Parking at a transit hub you use for your commute</Text>
+          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>• Monthly or daily parking passes bought for work travel</Text>
         </View>
 
         <View>
           <Text style={{ fontSize: 11, fontWeight: 'bold', marginBottom: 8, color: '#dc2626' }}>
-            Non-Eligible Expenses:
+            These do not qualify
           </Text>
-          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-            • Tolls and gas for personal vehicles
-          </Text>
-          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-            • Parking for personal errands or appointments
-          </Text>
-          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>
-            • Vehicle maintenance, insurance, or loan payments
-          </Text>
-          <Text style={{ fontSize: 9, color: '#374151' }}>
-            • Rides from personal car services (Uber, Lyft)
-          </Text>
+          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>• Gas, tolls, or mileage for your personal car</Text>
+          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>• Parking used for errands, entertainment, or personal appointments</Text>
+          <Text style={{ fontSize: 9, marginBottom: 3, color: '#374151' }}>• Car payments, maintenance, or insurance</Text>
+          <Text style={{ fontSize: 9, color: '#374151' }}>• Rideshare trips not connected to a vanpool program</Text>
         </View>
       </Section>
 
       <Divider />
 
       {/* Optimization Recommendations */}
-      <Section title="Optimization Recommendations">
+      <Section title="Next Steps to Use the Benefit">
         <Text style={{ fontSize: 10, marginBottom: 8, color: '#374151' }}>
-          Maximize your commuter benefit savings with these strategies:
+          Follow these plain-language steps to keep your commute tax savings on track:
         </Text>
-        
-        {inputs.transitCost > 315 && (
-          <Text style={{ fontSize: 9, marginBottom: 5, color: '#374151' }}>
-            • Your transit costs ({formatCurrency(inputs.transitCost)}) exceed the monthly limit. 
-            Consider if any expenses could be restructured to maximize the {formatCurrency(315)} monthly benefit.
-          </Text>
-        )}
-        
-        {inputs.parkingCost > 315 && (
-          <Text style={{ fontSize: 9, marginBottom: 5, color: '#374151' }}>
-            • Your parking costs ({formatCurrency(inputs.parkingCost)}) exceed the monthly limit. 
-            You'll save the maximum {formatCurrency((315 * (results.marginalRate / 100)) * 12)} annually on parking.
-          </Text>
-        )}
-        
-        {inputs.transitCost < 315 && inputs.parkingCost < 315 && (
-          <Text style={{ fontSize: 9, marginBottom: 5, color: '#374151' }}>
-            • You're well within both benefit limits. Consider if you have any additional eligible 
-            transportation expenses that could be included.
-          </Text>
-        )}
-        
+
         <Text style={{ fontSize: 9, marginBottom: 5, color: '#374151' }}>
-          • Enroll during your company's open enrollment period or when starting employment.
+          1. Confirm your monthly transit and parking costs. If they are above {formatCurrency(315)}, you will still get the
+          maximum tax-free amount and pay the rest with normal taxed pay.
         </Text>
-        
+
         <Text style={{ fontSize: 9, marginBottom: 5, color: '#374151' }}>
-          • Keep receipts and documentation for all commuter expenses in case of audit.
+          2. Enroll or update your election through your employer's commuter program and pick amounts up to the monthly limits.
+          Adjust during open enrollment or when your costs change.
         </Text>
-        
+
+        <Text style={{ fontSize: 9, marginBottom: 5, color: '#374151' }}>
+          3. Use the benefit card or submit receipts quickly. Substantiation is simply proving the expense was for your commute,
+          so upload tickets, invoices, or parking statements as you receive them.
+        </Text>
+
         <Text style={{ fontSize: 9, color: '#374151' }}>
-          • Review your commuting patterns annually as routes and costs may change.
+          4. Recheck your commute once or twice a year to make sure the deduction still matches your real costs.
         </Text>
       </Section>
 
@@ -230,15 +199,13 @@ export const CommuterReport: React.FC<CommuterReportProps> = ({ data }) => {
       {/* Important Notes */}
       <Section title="Important Program Details">
         <Note>
-          Commuter benefits are typically offered through employer-sponsored programs and may have 
-          different enrollment periods and rules. The pre-tax deduction reduces both federal income 
-          taxes and Social Security/Medicare taxes in most cases. State tax treatment may vary.
+          Commuter benefits come through your employer, so enrollment windows, payment cards, and deadlines can differ. The
+          pre-tax deduction usually lowers federal income and Social Security/Medicare taxes, but some states tax the benefit.
         </Note>
-        
+
         <Text style={{ fontSize: 8, marginTop: 8, color: '#6b7280' }}>
-          Benefits shown are based on 2025 IRS limits and your current tax bracket. Actual savings 
-          may vary based on total income, state taxes, and other deductions. Consult your HR department 
-          or tax advisor for specific program details and eligibility requirements.
+          The savings in this report use the 2025 IRS limits and the tax rate you entered. Your results can change if your pay or
+          state rules are different. Check with your HR team or a tax professional for the exact steps to join and stay compliant.
         </Text>
       </Section>
     </BaseDocument>

--- a/client/src/pages/calculator-hub.tsx
+++ b/client/src/pages/calculator-hub.tsx
@@ -35,7 +35,8 @@ export default function CalculatorHub() {
     {
       id: "commuter",
       title: "Commuter Benefits",
-      description: "Calculate pre-tax savings on transit and parking expenses for your daily commute.",
+      description:
+        "Learn how setting aside part of your paycheck before taxes can help cover transit passes and parking for your commute.",
       icon: Bus,
       route: "/commuter",
       analyticsId: "calculator-commuter-entry",

--- a/client/src/pages/commuter-calculator.tsx
+++ b/client/src/pages/commuter-calculator.tsx
@@ -83,7 +83,7 @@ export default function CommuterCalculator() {
               <div>
                 <Label className="flex items-center text-sm font-medium text-foreground mb-4">
                   Monthly Transit Costs: ${inputs.transitCost}
-                  <Tooltip content="Include what you spend each month on eligible public transportation—subways, buses, commuter rail, ferries, and qualified employer-sponsored vanpools. Federal rules cap the tax-free benefit at $315 per month in 2025, so amounts above that limit must be paid with after-tax dollars." />
+                  <Tooltip content="Eligible expenses are the rides the IRS says count for this benefit—monthly passes, pay-per-ride fares, or employer vanpools you use to get to work. You can move up to $315 per month in 2025 from your paycheck before taxes for these costs; anything over that comes out after tax." />
                 </Label>
                 <Slider
                   value={[inputs.transitCost]}
@@ -99,7 +99,7 @@ export default function CommuterCalculator() {
                   <span>$500</span>
                 </div>
                 <div className="mt-2 text-xs text-muted-foreground">
-                  2025 Monthly Limit: $315
+                  2025 monthly limit (the most you can set aside before taxes): $315
                 </div>
               </div>
 
@@ -107,7 +107,7 @@ export default function CommuterCalculator() {
               <div>
                 <Label className="flex items-center text-sm font-medium text-foreground mb-4">
                   Monthly Parking Costs: ${inputs.parkingCost}
-                  <Tooltip content="Add the average you pay to park at or near your workplace or a transit station. The IRS allows up to $315 per month in 2025 to be excluded from taxes when the parking space is tied to your commute; general street parking or mileage reimbursement is not covered." />
+                  <Tooltip content="Eligible parking means spaces tied to getting to work, like a garage at your office or lot at the train station. In 2025 you can shield up to $315 per month from taxes for this parking; paying more than that means the extra is taxed like normal pay." />
                 </Label>
                 <Slider
                   value={[inputs.parkingCost]}
@@ -123,7 +123,7 @@ export default function CommuterCalculator() {
                   <span>$500</span>
                 </div>
                 <div className="mt-2 text-xs text-muted-foreground">
-                  2025 Monthly Limit: $315
+                  2025 monthly limit (tax-free cap): $315
                 </div>
               </div>
 
@@ -253,13 +253,21 @@ export default function CommuterCalculator() {
             <h3 className="text-lg font-semibold text-foreground mb-4">TouchCare Transit Guidance</h3>
             <div className="space-y-3 text-sm text-muted-foreground">
               <p>
-                Pre-tax commuter benefits are capped at $315 per month for transit and $315 for parking in 2025 (IRS Rev. Proc. 2024-45). Savings shown assume payroll deductions and no local taxes.
+                A monthly limit is the most you can move from your paycheck before taxes. For 2025 that limit is $315 for transit and another $315 for parking. Money above those caps still pays for your commute, it just isn’t tax-free.
               </p>
               <p>
-                Submit eligible receipts promptly—many plans require substantiation within 180 days. Parking reimbursements often cover rideshare to transit hubs but not mileage to your office.
+                Eligible expenses are the commute costs tied directly to getting to work, like transit passes, vanpools, or parking next to your job or station. Substantiation simply means showing proof—usually uploading a receipt or pass—so keep those records handy and send them in within your plan’s deadline.
               </p>
+              <div className="space-y-1">
+                <p className="font-medium text-foreground text-xs uppercase tracking-wide">Quick steps</p>
+                <ol className="list-decimal list-inside space-y-1 text-xs text-muted-foreground">
+                  <li>Estimate your average monthly transit and parking costs.</li>
+                  <li>Enroll through your employer’s commuter program and choose amounts up to the monthly limits.</li>
+                  <li>Use the benefit card or submit receipts so your expenses stay tax-free.</li>
+                </ol>
+              </div>
               <p className="text-xs text-foreground">
-                Use this illustration for planning only. Final eligibility, ordering windows, and rollover rules are determined by your employer’s plan document and local ordinances.
+                Use this illustration for planning only. Your employer’s commuter benefit rules, local taxes, and deadlines will control the final details.
               </p>
             </div>
           </GlassCard>

--- a/client/src/pages/comparison-tool.tsx
+++ b/client/src/pages/comparison-tool.tsx
@@ -51,7 +51,7 @@ const calculatorTypes = [
     id: 'commuter' as const,
     name: 'Commuter Benefits',
     icon: Bus,
-    description: 'Compare pre-tax transit and parking benefit scenarios'
+    description: 'See how pre-tax transit and parking dollars change take-home pay across commute plans'
   },
   {
     id: 'life-insurance' as const,


### PR DESCRIPTION
## Summary
- rewrite commuter calculator, comparison tool, and hub copy to explain eligible expenses, monthly limits, and substantiation in plain language
- refresh commuter comparison tooltips, section headers, and benefit facts for clearer descriptions
- update the commuter PDF narrative with everyday explanations and next steps for using the benefit

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d6c8343dcc83209900be4e796057af